### PR TITLE
Fixed path definition error in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ parent(node)        →   typeof(node)
 ```julia
 using XML
 
-filename = joinpath(dirname(pathof(XML)), "..", "test", "books.xml")
+filename = joinpath(dirname(pathof(XML)), "..", "test", "data", "books.xml")
 
 doc = read(filename, Node)
 


### PR DESCRIPTION
The `README.md` contains an example to read in an XML file. There it specifies the path to a demo `.xml` file called `books.xml` like this: 
```julia
filename = joinpath(dirname(pathof(XML)), "..", "test", "books.xml")
```

However, this file is actually in the `data` folder within the `test` folder (https://github.com/JuliaComputing/XML.jl/tree/main/test/data), so I corrected the README to have: 

```julia
filename = joinpath(dirname(pathof(XML)), "..", "test", "data", "books.xml")
```