### PR TITLE
Ensure `XML.attributes(node) === nothing` when `node` has no attributes

### DIFF
--- a/src/XML.jl
+++ b/src/XML.jl
@@ -205,7 +205,12 @@ Base.setindex!(o::Node, val, i::Integer) = o.children[i] = Node(val)
 Base.push!(a::Node, b::Node) = push!(a.children, b)
 Base.pushfirst!(a::Node, b::Node) = pushfirst!(a.children, b)
 
-Base.setindex!(o::Node, val, key::AbstractString) = (o.attributes[key] = string(val))
+function Base.setindex!(o::Node, val, key::AbstractString) # Need to deal with case that XML.attributes(o) === nothing
+    o = isnothing(o.attributes) ? XML.Node(o.nodetype, o.tag, OrderedDict{String, String}(), o.value, o.children) : o
+    o.attributes[key] = string(val)
+    return o
+end
+# Base.setindex!(o::Node, val, key::AbstractString) = (o.attributes[key] = string(val))
 Base.getindex(o::Node, val::AbstractString) = o.attributes[val]
 Base.haskey(o::Node, key::AbstractString) = isnothing(o.attributes) ? false : haskey(o.attributes, key)
 Base.keys(o::Node) = isnothing(o.attributes) ? () : keys(o.attributes)

--- a/src/XML.jl
+++ b/src/XML.jl
@@ -171,7 +171,8 @@ Node(data::Raw) = Node(LazyNode(data))
 # Anything that's not Vector{UInt8} or a (Lazy)Node is converted to a Text Node
 Node(x) = Node(Text, nothing, nothing, string(x), nothing)
 
-h(tag::Union{Symbol, String}, children...; kw...) = Node(Element, tag, kw, nothing, children)
+h(tag::Union{Symbol, String}, children...; kw...) = Node(Element, tag, length(kw)==0 ? nothing : kw, nothing, children)
+# h(tag::Union{Symbol, String}, children...; kw...) = Node(Element, tag, kw, nothing, children)
 Base.getproperty(::typeof(h), tag::Symbol) = h(tag)
 (o::Node)(children...; kw...) = Node(o, Node.(children)...; kw...)
 
@@ -240,7 +241,8 @@ function (T::NodeType)(args...; attr...)
         Node(T, nothing, nothing, only(args))
     elseif T === Element
         tag = first(args)
-        Node(T, tag, attr, nothing, args[2:end])
+        Node(T, tag, length(attr)==0 ? nothing : attr, nothing, args[2:end])
+#        Node(T, tag, attr, nothing, args[2:end])
     else
         error("Unreachable reached while trying to create a Node via (::NodeType)(args...; kw...).")
     end


### PR DESCRIPTION
Speculative suggestion to fix issue #33 - proposed for review.
Tests pass locally but I think this needs deeper understanding than I can bring.
I have focused only on `XML.Element`s.