### PR TITLE
Fix depth and parent functions

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -1,0 +1,38 @@
+name: Downstream
+on:
+  push:
+    branches: [main]
+    tags: [v*]
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - "XLSX"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: 1
+          arch: x64
+          show-versioninfo: true
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Load this and run the downstream tests
+        shell: julia --color=yes {0}
+        run: |
+          using Pkg
+          Pkg.Registry.update()
+          Pkg.activate(;temp=true)
+          # force it to use this PR's version of the package
+          ENV["JULIA_PKG_DEVDIR"]= mktempdir()
+          Pkg.develop([
+            PackageSpec(path="."),
+            PackageSpec(name="${{ matrix.package }}"),
+          ])
+          Pkg.update()
+          Pkg.test("${{ matrix.package }}")

--- a/src/XML.jl
+++ b/src/XML.jl
@@ -257,7 +257,7 @@ attributes(o) = o.attributes
 value(o) = o.value
 children(o::T) where {T} = isnothing(o.children) ? () : o.children
 
-depth(o) = 1
+depth(o) = missing
 parent(o) = missing
 next(o) = missing
 prev(o) = missing
@@ -357,7 +357,7 @@ write(x; kw...) = (io = IOBuffer(); write(io, x; kw...); String(take!(io)))
 
 write(filename::AbstractString, x; kw...) = open(io -> write(io, x; kw...), filename, "w")
 
-function write(io::IO, x; indentsize::Int=2, depth::Int=depth(x))
+function write(io::IO, x; indentsize::Int=2, depth::Int=1)
     indent = ' ' ^ indentsize
     nodetype = XML.nodetype(x)
     tag = XML.tag(x)

--- a/src/raw.jl
+++ b/src/raw.jl
@@ -209,13 +209,22 @@ function children(o::Raw)
 end
 
 """
+    depth(node) --> Int
+
+Return the depth of the node.  Will be `0` for `Document` nodes.  Not defined for `XML.Node`.
+"""
+function depth(o::Raw)
+    o.depth
+end
+
+"""
     parent(node) --> typeof(node), Nothing
 
 Return the parent of the node.  Will be `nothing` for `Document` nodes.  Not defined for `XML.Node`.
 """
 function parent(o::Raw)
     depth = o.depth
-    depth === 1 && return nothing
+    depth === 0 && return nothing
     p = prev(o)
     while p.depth >= depth
         p = prev(p)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -134,6 +134,18 @@ end
         end
     end
 
+    @testset "depth and parent" begin
+        @test XML.depth(data) == 0
+        @test isnothing(XML.parent(data))
+        @test XML.depth(doc[1]) == 1
+        @test XML.parent(doc[1]) == data
+        @test XML.depth(doc[2]) == 1
+        @test XML.depth(doc[3]) == 2
+        @test XML.parent(doc[3]) == doc[2]
+        @test XML.depth(doc[end]) == 1
+        @test XML.parent(doc[end]) == data
+    end
+
     @testset "tag/attributes/value" begin
         x = doc[1]  # <?xml version="1.0"?>
         @test XML.tag(x) === nothing


### PR DESCRIPTION
Fixes #36 and adds more tests.

Currently, `depth` starts at `0`, but was it intended to start at `1`?