### PR TITLE
String -> Base.String

### DIFF
--- a/src/raw.jl
+++ b/src/raw.jl
@@ -87,7 +87,7 @@ function Base.:(==)(a::Raw, b::Raw)
 end
 
 Base.view(o::Raw) = view(o.data, o.pos:o.pos + o.len)
-String(o::Raw) = String(view(o))
+Base.String(o::Raw) = String(view(o))
 
 Base.IteratorSize(::Type{Raw}) = Base.SizeUnknown()
 Base.eltype(::Type{Raw}) = Raw


### PR DESCRIPTION
Extending a constructor from Base requires explicit qualification in Julia 1.13.