### PR TITLE
Add `Base.copy(::Node)` and reflect this in docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,19 +99,51 @@ node["key"] = value
 node["key"]
 ```
 
-- `Node` is an immutable type.  However, you can easily create a copy with one or more field values changed by using the `Node(::Node; kw...)` constructor where `kw` are the fields you want to change.  For example:
+- `Node` is an immutable type.  However, you can easily create a simple copy using `copy(::Node)` or 
+copy with one or more changes by using the `Node(::Node, atts...; kw...)` constructor where `atts` 
+are new children to add and `kw` are the node attributes you want to add or change.  For example:
 
 ```julia
-node = XML.Element("tag", XML.Text("child"))
+julia> node = XML.Element("tag", XML.Text("child"))
+Node Element <tag> (1 child)
 
-simple_value(node)
-# "child"
+julia> simple_value(node)
+"child"
 
-node2 = Node(node, children=XML.Text("changed"))
+julia> node2 = Node(node, new_att="I'm new")
+Node Element <tag new_att="I'm new"> (1 child)
 
-simple_value(node2)
-# "changed"
+julia> node3 = Node(node2, XML.Element("new_child", child_att="I'm new too"))
+Node Element <tag new_att="I'm new"> (2 children)
+
+julia> println(XML.write(node))
+<tag>child</tag>
+
+julia> println(XML.write(node2))
+<tag new_att="I'm new">child</tag>
+
+julia> println(XML.write(node3))
+<tag new_att="I'm new">
+  child
+  <new_child child_att="I'm new too"/>
+</tag>
+
+julia> node4=copy(node3)
+Node Element <tag new_att="I'm new"> (2 children)
+
+julia> println(XML.write(node4))
+<tag new_att="I'm new">
+  child
+  <new_child child_att="I'm new too"/>
+</tag>
+
+julia> node4==node3
+true
+
+julia> node4===node3
+false
 ```
+
 
 ### Writing `Element` `Node`s with `XML.h`
 

--- a/src/XML.jl
+++ b/src/XML.jl
@@ -269,6 +269,10 @@ simple_value(o) = is_simple(o) ? value(only(o)) : error("`XML.simple_value` is o
 
 Base.@deprecate_binding simplevalue simple_value
 
+#-----------------------------------------------------------------------------# copy node
+
+Base.copy(o::AbstractXMLNode) = Node(o.nodetype, o.tag, o.attributes, o.value, isnothing(o.children) ? nothing : [Base.copy(x) for x in o.children])
+
 #-----------------------------------------------------------------------------# nodes_equal
 function nodes_equal(a, b)
     out = XML.tag(a) == XML.tag(b)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -174,6 +174,16 @@ end
     end
 end
 
+#-----------------------------------------------------------------------------# copy
+@testset "Copy node" begin
+    for path in all_files
+        node = read(path, Node)
+        node2 = copy(node)
+        @test node == node2
+        @test node2==deepcopy(node)
+    end
+end
+
 #-----------------------------------------------------------------------------# roundtrip
 @testset "read/write/read roundtrip" begin
     for path in all_files


### PR DESCRIPTION
I've added a simple function to recursively copy a node and all its children. I've added some tests for this, too.

The text on the `Readme` page currently says:

* Node is an immutable type. However, you can easily create a copy with one or more field values changed by using the Node(::Node; kw...) constructor where kw are the fields you want to change. For example:

```
node = XML.Element("tag", XML.Text("child"))

simple_value(node)
# "child"

node2 = Node(node, children=XML.Text("changed"))

simple_value(node2)
# "changed"
```
This seems to be a bit out of date. The `Node()` function seems to treat arguments as new children and keywords as new/changed attributes. The example presented now seems to create an attribute called "children" rather than changing the child node. I've suggested some changes to the `Readme` to reflect this.

(Hope this goes OK this time!)