### PR TITLE
CData -> CDATA

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ doc[end][2]  # Second child of root
 | `Declaration` | `<?xml attributes... ?>` | `Declaration(; attrs...)`
 | `ProcessingInstruction` | `<?tag attributes... ?>` | `ProcessingInstruction(tag; attrs...)`
 | `Comment` | `<!-- text -->` | `Comment(text)`
-| `CData` | `<![CData[text]]>` | `CData(text)`
+| `CData` | `<![CDATA[text]]>` | `CData(text)`
 | `Element` | `<tag attributes... > children... </NAME>` | `Element(tag, children...; attrs...)`
 | `Text` | the `text` part of `<tag>text</tag>` | `Text(text)`
 

--- a/src/XML.jl
+++ b/src/XML.jl
@@ -36,7 +36,7 @@ end
     - Declaration               # <?xml attributes... ?>
     - ProcessingInstruction    # <?NAME attributes... ?>
     - Comment                   # <!-- ... -->
-    - CData                     # <![CData[...]]>
+    - CData                     # <![CDATA[...]]>
     - Element                   # <NAME attributes... > children... </NAME>
     - Text                      # text
 
@@ -324,7 +324,7 @@ function _show_node(io::IO, o)
         printstyled(io, value(o), color=:light_black)
         printstyled(io, "-->", color=:light_cyan)
     elseif o.nodetype === CData
-        printstyled(io, " <![CData[", color=:light_cyan)
+        printstyled(io, " <![CDATA[", color=:light_cyan)
         printstyled(io, value(o), color=:light_black)
         printstyled(io, "]]>", color=:light_cyan)
     elseif o.nodetype === Document
@@ -408,7 +408,7 @@ function write(io::IO, x, ctx::Vector{Bool}=[false]; indentsize::Int=2, depth::I
         print(io, "<!--", value, "-->")
 
     elseif nodetype === CData
-        print(io, "<![CData[", value, "]]>")
+        print(io, "<![CDATA[", value, "]]>")
 
     elseif nodetype === Document
         foreach(children) do child

--- a/src/raw.jl
+++ b/src/raw.jl
@@ -3,7 +3,7 @@
     RawType:
     - RawText                   # text
     - RawComment                # <!-- ... -->
-    - RawCData                  # <![CData[...]]>
+    - RawCData                  # <![CDATA[...]]>
     - RawDeclaration            # <?xml attributes... ?>
     - RawProcessingInstruction  # <?NAME attributes... ?>
     - RawDTD                    # <!DOCTYPE ...>
@@ -37,7 +37,7 @@ Create an iterator over raw chunks of data in an XML file.  Each chunk of data r
     - RawDocument                # Only used to initialize the iterator state.
     - RawText                    # text
     - RawComment                 # <!-- ... -->
-    - RawCData                   # <![CData[...]]>
+    - RawCData                   # <![CDATA[...]]>
     - RawDeclaration             # <?xml attributes... ?>
     - RawProcessingInstruction   # <?NAME attributes... ?>
     - RawDTD                     # <!DOCTYPE ...>
@@ -271,7 +271,7 @@ function value(o::Raw)
     if o.type === RawText
         String(o)
     elseif o.type === RawCData
-        String(view(o.data, o.pos+length("<![CData["):o.pos+o.len-3))
+        String(view(o.data, o.pos+length("<![CDATA["):o.pos+o.len-3))
     elseif o.type === RawComment
         String(view(o.data, o.pos+length("<!--"):o.pos+o.len-3))
     elseif o.type === RawDTD
@@ -534,7 +534,7 @@ function prev_no_xml_space(o::Raw) # same as v0.3.5
             i = findprev(Vector{UInt8}("<--"), data, j)[1]
         elseif c2 === ']'
             type = RawCData
-            i = findprev(Vector{UInt8}("<![CData["), data, j)[1]
+            i = findprev(Vector{UInt8}("<![CDATA["), data, j)[1]
         elseif c2 === '?'
             i = findprev(Vector{UInt8}("<?"), data, j)[1]
             if get_name(data, i + 2)[1] == "xml"

--- a/test/data/example.kml
+++ b/test/data/example.kml
@@ -3,7 +3,7 @@
 <kml xmlns="http://earth.google.com/kml/2.2">
   <Document>
     <name>Example KML file</name>
-    <description><![CData[Example KML file]]></description>
+    <description><![CDATA[Example KML file]]></description>
     <!-- here is a comment -->
     <Style id="style1">
       <IconStyle>
@@ -31,7 +31,7 @@
     </Style>
     <Placemark>
       <name>Time Square</name>
-      <description><![CData[Times Square is a major commercial intersection and neighborhood in Midtown Manhattan, New York City.]]></description>
+      <description><![CDATA[Times Square is a major commercial intersection and neighborhood in Midtown Manhattan, New York City.]]></description>
       <styleUrl>#style1</styleUrl>
       <Point>
         <coordinates>-73.984939,40.758874,0.000000</coordinates>
@@ -39,7 +39,7 @@
     </Placemark>
     <Placemark>
       <name>Central Park</name>
-      <description><![CData[Central Park is an urban park in middle-upper Manhattan, within New York City.]]></description>
+      <description><![CDATA[Central Park is an urban park in middle-upper Manhattan, within New York City.]]></description>
       <styleUrl>#style2</styleUrl>
       <Polygon>
         <outerBoundaryIs>
@@ -57,7 +57,7 @@
     </Placemark>
     <Placemark>
       <name>Lincoln Tunnel</name>
-      <description><![CData[Traffic(under 10 minutes)]]></description>
+      <description><![CDATA[Traffic(under 10 minutes)]]></description>
       <styleUrl>#style3</styleUrl>
       <LineString>
         <tessellate>1</tessellate>

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,7 +78,7 @@ end
             tag=nothing,
             attributes=nothing,
             value=" comment "),
-        (xml = "<![CData[cdata test]]>",
+        (xml = "<![CDATA[cdata test]]>",
             nodetype = CData,
             tag=nothing,
             attributes=nothing,


### PR DESCRIPTION
From https://www.w3.org/TR/xml/:

<img width="1918" height="711" alt="image" src="https://github.com/user-attachments/assets/98424ed6-0e5c-4b90-9588-4176354d5425" />


The spec seems to show only CDATA in all caps. The issue is of course that this package writes "CData", with the last 3 letters lowercase. I noticed this when working on a GPX file, and [this GPX validator](https://www.freeformatter.com/xml-validator-xsd.html) shows an error when CDATA is not in all caps for the following XML content:
```xml
  <?xml version="1.0"?>
<gpx version="1.1" creator="CoMaps" xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns:gpx_style="http://www.topografix.com/GPX/gpx_style/0/2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 https://www.topografix.com/GPX/1/1/gpx.xsd http://www.topografix.com/GPX/gpx_style/0/2 https://www.topografix.com/GPX/gpx_style/0/2/gpx_style.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 https://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd">
  <metadata>
    <name>Bookmarks</name>
  </metadata>
<wpt lat="23.966643" lon="55.736415">
    <name>My Tag Name</name>
    <desc>
      <![CData[R&B]]>
    </desc>
</wpt>
</gpx>
```

To fix this, this PR replaces `<![CData[` with `<![CDATA[` in all files in this package. It does not change the capitalization of the types themselves, which should of course follow the julia convention.