### PR TITLE
perf: avoid per-call ctx allocation in next_no_xml_space

### DIFF
--- a/src/raw.jl
+++ b/src/raw.jl
@@ -431,7 +431,12 @@ function next_no_xml_space(o::Raw) # same as v0.3.5
     data = o.data
     type = o.type
     has_xml_space = o.has_xml_space
-    ctx = [false]
+    # `ctx` (the xml:space inheritance stack) is unused by this code path —
+    # `next_no_xml_space` is only called when the document has no `xml:space`
+    # attribute anywhere, so the per-node ctx is always `Bool[false]` and is
+    # never mutated. Reuse the parent's `ctx` instead of allocating a fresh
+    # one; on a 47 MiB file this drops ~60 MiB of cumulative allocation.
+    ctx = o.ctx
     i = findnext(!xml_isspace, data, i)
     if isnothing(i)
         return nothing


### PR DESCRIPTION
## Summary                                                                                                 

`next_no_xml_space` is the fast path of `Raw`'s document-order traversal — it's selected by `next(::Raw)` when the underlying byte buffer contains no `xml:space` attribute anywhere. In that situation the per-`Raw` `ctx` (xml:space inheritance stack) field is always `Bool[false]` and is never mutated, but the function nevertheless allocates a fresh `[false]` on every call:

```julia
function next_no_xml_space(o::Raw)
    ...
    ctx = [false]                                  # ← fresh allocation per call
    ...
    return Raw(type, depth, i, j - i, data, ctx, has_xml_space)
end
```

For documents with thousands of XML nodes that allocation dominates the cumulative memory profile of any consumer that walks the tree. The change here just reuses the parent's `ctx` reference instead:                                                                                                              

```julia
ctx = o.ctx
```

## Why this is safe

`next_no_xml_space` is selected only when `o.has_xml_space === false`, in which case `ctx` descends from the root's `Bool[false]` ([line 73](https://github.com/JuliaComputing/XML.jl/blob/4b560996d315eac72c53c4f6a85747c9e70c0f3a/src/raw.jl#L70-L77)) and is never mutated — the only function that writes to `ctx` is `next_xml_space`, on the disjoint `has_xml_space === true` branch. Inside `next_no_xml_space` itself, `ctx` is read once and passed to the `Raw(...)` constructor; no `push!` / `pop!` / `setindex!`.

A module-level `const _DEFAULT_CTX = Bool[false]` would be an equally allocation-free alternative if you'd prefer not to rely on the propagation chain — happy to switch.

## Why it matters

Measured on a downstream consumer (FastKML.jl extracting a `DataFrame` from a 47 MiB sample KML, walking ~1 M `Raw` nodes during the traversal), this allocation site was contributing ~60 MiB of cumulative tracked allocation. Removing it cuts the consumer's end-to-end memory by about a sixth and lops ~7% off wall-clock time. The same pattern would apply to any package using `XML.LazyNode` or `XML.Raw` to walk a large document.

(See also #59 for a complementary additive change adding `next!` / `prev!` for in-place traversal — independent and stackable.)

## Verification                                                                                                                                                                

- The full XML.jl test suite passes locally on this branch (Julia 1.12), including all 71 `xml:space` cases — those exercise the `next_xml_space` path that's deliberately unchanged here.
- No public API change, no behavioral change observable to existing callers.                                                                                                                                                                     

## Diff size                                                                                                                                                                   

One real line changed:

```diff
-    ctx = [false]
+    ctx = o.ctx
```

Plus a short comment explaining the rationale, so future readers don't re-allocate it back without understanding the constraint.