### PR TITLE
Bump compat for OrderedCollections.jl, bump patch version for new release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "XML"
 uuid = "72c71f33-b9b6-44de-8c94-c961784809e2"
 authors = ["Josh Day <emailjoshday@gmail.com> and contributors"]
-version = "0.3.8"
+version = "0.3.9"
 
 [deps]
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"

--- a/Project.toml
+++ b/Project.toml
@@ -8,5 +8,5 @@ Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 
 [compat]
-OrderedCollections = "1.4, 1.5"
+OrderedCollections = "1.4, 1.5, 2"
 julia = "1.6"


### PR DESCRIPTION
The new release of OrderedCollections.jl is removing long-standing deprecations

https://github.com/JuliaCollections/OrderedCollections.jl/releases/tag/v2.0.0