### PR TITLE
Prepare 0.3.9: changelog + regression tests (#56, #60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+Itemised from v0.3.9 onward; for earlier releases see the
+[GitHub releases](https://github.com/JuliaData/XML.jl/releases) and git tags.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.3.9] - 2026-06-20
+
+First release since XML.jl moved to [JuliaData](https://github.com/JuliaData/XML.jl) (transferred from JuliaComputing).
+
+### Added
+- `next!` and `prev!` for in-place, zero-allocation forward/backward traversal of `LazyNode` ([#59]).
+
+### Fixed
+- CDATA sections are now read and written with the spec-correct `<![CDATA[ … ]]>` delimiter.
+  The previous `<![CData[` spelling is invalid XML and did not interoperate with other parsers ([#56]).
+- `escape` now accepts any `AbstractString` (e.g. `SubString`), not only `String` ([#60]).
+
+### Changed
+- Relaxed the OrderedCollections.jl compat bound to include v2 ([#64]).
+
+[0.3.9]: https://github.com/JuliaData/XML.jl/compare/v0.3.8...v0.3.9
+[#56]: https://github.com/JuliaData/XML.jl/pull/56
+[#59]: https://github.com/JuliaData/XML.jl/pull/59
+[#60]: https://github.com/JuliaData/XML.jl/pull/60
+[#64]: https://github.com/JuliaData/XML.jl/pull/64

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ end
     @test escape(escape(s)) == escape(s)
     @test s == unescape(escape(s))
     @test s == unescape(unescape(escape(s)))
+    @test escape(SubString("a&b<c>", 1)) == "a&amp;b&lt;c&gt;"   # #60: SubString input (was a MethodError)
 
     n = Element("tag", Text(s))
     @test XML.simple_value(n) == s
@@ -202,6 +203,13 @@ end
         n=XML.prev(n)
         text_content = XML.write(n)
         @test text_content == "<root>\n  <text/>\n  <text2>hello</text2>\n  <text3 xml:space=\"preserve\">  hello  <text3b>  preserve  </text3b></text3>\n  <text4 xml:space=\"preserve\"/>\n  <text5/>\n</root>"
+        # #56: prev must cross a CDATA section (the call itself threw before the delimiter fix)
+        cdoc = XML.parse(XML.LazyNode, "<r><a>x</a><![CDATA[hello]]><b>y</b></r>")
+        cb = XML.children(XML.children(cdoc)[1])[3]   # the <b> element
+        cp = XML.prev(cb)
+        @test cp isa XML.LazyNode                      # does not throw
+        @test XML.nodetype(cp) == XML.CData
+        @test XML.value(cp) == "hello"
     end
 
     @testset "depth and parent" begin


### PR DESCRIPTION
Tidy-up before registering v0.3.9.

- **`CHANGELOG.md`** (new) — itemises the four user-facing PRs since 0.3.8 (#56, #59, #60, #64), starting the changelog at 0.3.9 (earlier history via the releases/tags); notes the move to JuliaData.
- **Regression tests** — #56 and #60 merged without their own coverage. These guard both fixes: `prev()` crossing a CDATA section (#56) and `escape(::SubString)` (#60). Green on `main`.