### PR TITLE
ci: fix CI badge URL → JuliaData + add codecov.yml

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,13 @@
+# https://docs.codecov.com/docs/codecov-yaml
+# Coverage is reported but never blocks CI (informational) until the team decides on targets.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+comment:
+  layout: "reach, diff, files"
+  require_changes: true   # only comment on PRs that actually change coverage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/JuliaComputing/XML.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/JuliaComputing/XML.jl/actions/workflows/CI.yml)
+[![CI](https://github.com/JuliaData/XML.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/JuliaData/XML.jl/actions/workflows/CI.yml)
 
 <h1 align="center">XML.jl</h1>
 


### PR DESCRIPTION
- **README:** point the CI badge at `JuliaData/XML.jl` — it still pointed at `JuliaComputing` (working only via redirect since the move).
- **`.github/codecov.yml`:** coverage reported as *informational* (never blocks CI) + a PR comment when coverage changes.

A coverage badge is deferred to a follow-up: Codecov still tracks the package under the old `JuliaComputing` path (63%) and has no data under `JuliaData`, so a badge would render "unknown" until that's reconciled — see below.

@ViralBShah — two Codecov items need admin:
1. **Activate the repo on Codecov under JuliaData** — it still tracks `JuliaComputing/XML.jl` (63% coverage); `JuliaData/XML.jl` has no data, so uploads/badges don't land there.
2. **Set a `CODECOV_TOKEN` repo secret** — CI passes no token to `codecov-action@v7`, so uploads can intermittently rate-limit (the step still exits green, masking it).

With both, uploads land under JuliaData and a coverage badge will render a real number.