### PR TITLE
Add Codecov coverage badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/JuliaData/XML.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/JuliaData/XML.jl/actions/workflows/CI.yml)
+[![CI](https://github.com/JuliaData/XML.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/JuliaData/XML.jl/actions/workflows/CI.yml) [![codecov](https://codecov.io/gh/JuliaData/XML.jl/graph/badge.svg)](https://codecov.io/gh/JuliaData/XML.jl)
 
 <h1 align="center">XML.jl</h1>
 


### PR DESCRIPTION
Coverage is live (Codecov wired in #74 + org token; main at 74%). Adds the coverage badge beside the CI badge.

Does not close #73. See https://github.com/JuliaData/XML.jl/issues/73#issuecomment-4762578135