### PR TITLE
Release v0.4.2 (WIP) — FlatNode (experimental), node identity, hash(::Node) fix

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -12,14 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # XLSX's XML-v0.4 adaptation (JuliaData/XLSX.jl#415). The *registered* XLSX
-          # pins XML 0.3, so testing it against this branch fails by design; test the
-          # adaptation PR instead. Once #415 merges and releases, point this back at
-          # the registered package (PackageSpec(name=...) as before).
-          - package: XLSX
-            repository: JuliaData/XLSX.jl
-            ref: refs/pull/415/head
+        package:
+          - "XLSX"
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
@@ -28,21 +22,17 @@ jobs:
           arch: x64
           show-versioninfo: true
       - uses: julia-actions/julia-buildpkg@latest
-      - uses: actions/checkout@v7
-        with:
-          repository: ${{ matrix.repository }}
-          ref: ${{ matrix.ref }}
-          path: downstream
       - name: Load this and run the downstream tests
         shell: julia --color=yes {0}
         run: |
           using Pkg
           Pkg.Registry.update()
           Pkg.activate(;temp=true)
-          # this branch's XML + the downstream package's adaptation branch
+          # force it to use this PR's version of the package
+          ENV["JULIA_PKG_DEVDIR"]= mktempdir()
           Pkg.develop([
             PackageSpec(path="."),
-            PackageSpec(path="downstream"),
+            PackageSpec(name="${{ matrix.package }}"),
           ])
           Pkg.update()
           Pkg.test("${{ matrix.package }}")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entity-decoded on access), so building is fast, random access is O(1), and the GC sees a
   handful of arrays instead of one object per node — *`Node`'s read half at `Cursor`'s GC
   cost*. Extras over `Node`: O(1) `parent`, O(depth) 1-arg `depth`. By design: read-only,
-  whole-store retention, 2 GiB/`typemax(Int32)` limits (use `Node` beyond). `==`/`hash` on
-  `FlatNode` are positional identity (same store, same node). `Node(flatnode)` materializes
-  a handle as a mutable `Node`; `XML.write` accepts `FlatNode` directly. Same
-  well-formedness levels and error messages as the `Node` parser (#82).
+  whole-store retention, 2 GiB/`typemax(Int32)` limits (use `Node` beyond). `Node(flatnode)`
+  materializes a handle as a mutable `Node`; `XML.write` accepts `FlatNode` directly. Same
+  well-formedness levels and error messages as the `Node` parser. **Marked experimental**
+  while its usage settles in the dependent ecosystem: API details may still change in a
+  0.4.x release (#82).
+
+- **`issamenode(a, b)` — positional identity for the handle readers** (`FlatNode`: same
+  store + same index; `LazyNode`: same source object + same token): "is this the same node
+  of the same document", which neither `==` (structural equality) nor `===` (egal is
+  content-based on immutable handles) can express (#83).
+
+### Changed
+
+- **`==`/`isequal`/`hash` are structural for every tree reader, cross-reader included** —
+  same decoded nodetype/tag/attributes (order-insensitive)/value/children (in document
+  order), recursively. `Node` already compared structurally; `LazyNode` (previously the
+  egal fallback) and `FlatNode` (previously positional) now match it, and
+  `Node == LazyNode == FlatNode` holds for equal content (#83). Migration: code that used
+  `FlatNode` `==` as "same node" should use `issamenode`.
+
+- **Search-based `Node` navigation raises an error on indistinguishable occurrences**:
+  `parent`/`depth`/`siblings`/XPath `..` match by egal, which is content-based on parsed
+  immutable nodes — in a tree with several value-identical occurrences (e.g. twin
+  `<item/>` elements) they silently answered for the first match, yielding wrong depths
+  and sibling lists. Unambiguous calls are unchanged. Migration: for positional navigation
+  in such documents, use `FlatNode` (parent links, no ambiguity).
+
+### Fixed
+
+- **`hash(::Node)` restores the `==`/`hash` contract** (#55): `Node` compared structurally
+  but hashed by `objectid`, so `unique`/`Dict`/`Set` misbehaved on equal nodes.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to XML.jl will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.2] - 2026-07-16
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`FlatNode` — a fourth reader: read-only columnar full-DOM** (`parse(xml, FlatNode)`,
+  `read(file, FlatNode)`). The whole document is materialized once into a contiguous store of
+  isbits records (zero-copy byte ranges into the retained source; text/attribute values
+  entity-decoded on access), so building is fast, random access is O(1), and the GC sees a
+  handful of arrays instead of one object per node — *`Node`'s read half at `Cursor`'s GC
+  cost*. Extras over `Node`: O(1) `parent`, O(depth) 1-arg `depth`. By design: read-only,
+  whole-store retention, 2 GiB/`typemax(Int32)` limits (use `Node` beyond). `==`/`hash` on
+  `FlatNode` are positional identity (same store, same node). `Node(flatnode)` materializes
+  a handle as a mutable `Node`; `XML.write` accepts `FlatNode` directly. Same
+  well-formedness levels and error messages as the `Node` parser (#82).
+
 ### Internal
 
 - Source layout: the `src/XML.jl` monolith (1409 lines) is split into dedicated files —

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "XML"
 uuid = "72c71f33-b9b6-44de-8c94-c961784809e2"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Josh Day <emailjoshday@gmail.com> and contributors"]
 
 [weakdeps]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ XML.jl ships four readers behind one set of accessors (`nodetype`, `tag`, `attri
 |---|---|---|---|---|
 | `Cursor` | no (nothing) | impossible (forward-only) | — | ~0 |
 | `LazyNode` | virtual | re-decode per visit (pay-per-traversal) | no | ~0 |
-| `FlatNode` | yes, compact (columnar) | O(1), paid once | no | ~0 |
+| `FlatNode` *(experimental)* | yes, compact (columnar) | O(1), paid once | no | ~0 |
 | `Node` | yes, objects | O(1), paid once | **yes** | high |
 
 Rules of thumb: one forward pass → `Cursor` · extract a little, memory-tight → `LazyNode` ·

--- a/README.md
+++ b/README.md
@@ -31,6 +31,25 @@ doc[end][2]  # Second child of root
 
 <br>
 
+# Choosing a reader
+
+XML.jl ships four readers behind one set of accessors (`nodetype`, `tag`, `attributes`,
+`value`, `children`, `eachelement`, …). Pick by what you do with the document:
+
+| Reader | DOM materialized? | Revisit a node | Mutable | GC cost |
+|---|---|---|---|---|
+| `Cursor` | no (nothing) | impossible (forward-only) | — | ~0 |
+| `LazyNode` | virtual | re-decode per visit (pay-per-traversal) | no | ~0 |
+| `FlatNode` | yes, compact (columnar) | O(1), paid once | no | ~0 |
+| `Node` | yes, objects | O(1), paid once | **yes** | high |
+
+Rules of thumb: one forward pass → `Cursor` · extract a little, memory-tight → `LazyNode` ·
+read-heavy full document, repeated traversals → `FlatNode` (*`Node`'s read half at `Cursor`'s
+GC cost*) · build or edit documents → `Node`. `FlatNode` and `LazyNode` retain the source
+string as long as any handle lives.
+
+<br>
+
 # `Node` Interface
 
 Every node in the XML DOM is represented by `Node`, a single type parametrized on its string storage.

--- a/benchmarks/flatnode_bench.jl
+++ b/benchmarks/flatnode_bench.jl
@@ -1,0 +1,72 @@
+# FlatNode exhaustive in-package benchmark — by regime, min of N runs, vs Node/LazyNode/EzXML.
+#   julia benchmarks/flatnode_bench.jl   (self-contained temp env: dev XML from this checkout + EzXML)
+using Pkg
+Pkg.activate(; temp = true, io = devnull)
+Pkg.develop(path = joinpath(@__DIR__, ".."), io = devnull)
+Pkg.add("EzXML", io = devnull)
+using XML, EzXML
+
+const xmark = joinpath(@__DIR__, "data", "xmark.xml")
+const xml = read(xmark, String)
+println("corpus: ", basename(xmark), " (", round(ncodeunits(xml) / 2^20, digits = 1), " MiB)")
+
+minN(f, n = 5) = minimum((GC.gc(); @elapsed f()) for _ in 1:n)
+allocs(f) = (GC.gc(); Base.gc_num().allocd; a0 = Base.gc_bytes(); f(); Base.gc_bytes() - a0)
+
+# ── build ──
+fbuild() = parse(xml, FlatNode; wellformed = :lenient)
+nbuild() = parse(xml, Node; wellformed = :lenient)
+ezbuild() = EzXML.parsexml(xml)
+for (nm, f) in ["FlatNode" => fbuild, "Node" => nbuild, "EzXML" => ezbuild]
+    println("build   ", rpad(nm, 9), lpad(round(minN(f) * 1000, digits = 1), 8), " ms")
+end
+
+# ── traverse (count nodes via each reader's handles) ──
+const F = fbuild(); const N = nbuild(); const EZ = ezbuild()
+function fwalk(n, c = Ref(0))
+    c[] += 1
+    for ch in XML.eachchildnode(n); fwalk(ch, c); end
+    c[]
+end
+function nwalk(n, c = Ref(0))
+    c[] += 1
+    for ch in children(n); nwalk(ch, c); end
+    c[]
+end
+function curwalk()
+    c = Cursor(xml); n = 0
+    while next!(c) !== nothing; n += 1; end
+    n
+end
+println("nodes: flat=", fwalk(FlatNode(F.store, Int32(1))), " node=", nwalk(N))
+for (nm, f) in ["FlatNode" => () -> fwalk(FlatNode(F.store, Int32(1))), "Node" => () -> nwalk(N), "Cursor" => curwalk]
+    println("walk    ", rpad(nm, 9), lpad(round(minN(f) * 1000, digits = 2), 8), " ms")
+end
+
+# ── extract (tag/value byte sums through the public accessors) ──
+function fextract(n, acc = Ref(0))
+    t = tag(n); v = value(n)
+    t === nothing || (acc[] += ncodeunits(t)); v === nothing || (acc[] += ncodeunits(v))
+    for ch in XML.eachchildnode(n); fextract(ch, acc); end
+    acc[]
+end
+function nextract(n, acc = Ref(0))
+    t = tag(n); v = value(n)
+    t === nothing || (acc[] += ncodeunits(t)); v === nothing || (acc[] += ncodeunits(v))
+    for ch in children(n); nextract(ch, acc); end
+    acc[]
+end
+println("extract sums: flat=", fextract(FlatNode(F.store, Int32(1))), " node=", nextract(N))
+for (nm, f) in ["FlatNode" => () -> fextract(FlatNode(F.store, Int32(1))), "Node" => () -> nextract(N)]
+    println("extract ", rpad(nm, 9), lpad(round(minN(f) * 1000, digits = 2), 8), " ms")
+end
+
+# ── retained + build allocations ──
+println("retained  FlatNode ", lpad(round(Base.summarysize(F.store) / 2^20, digits = 1), 7), " MiB   ",
+        "Node ", lpad(round(Base.summarysize(N) / 2^20, digits = 1), 7), " MiB")
+println("buildalloc FlatNode ", lpad(round(allocs(fbuild) / 2^20, digits = 1), 6), " MiB   ",
+        "Node ", lpad(round(allocs(nbuild) / 2^20, digits = 1), 6), " MiB")
+
+# ── GC pressure: full collection time with the tree live ──
+gcms(x) = (GC.gc(); t = @elapsed GC.gc(true); t * 1000)
+println("GC full  with FlatNode live ", round(gcms(F), digits = 2), " ms   with Node live ", round(gcms(N), digits = 2), " ms")

--- a/src/XML.jl
+++ b/src/XML.jl
@@ -7,7 +7,7 @@ export
     eachelement, elements,
     foreach_attr,
     is_simple, simple_value, is_simple_value, sourcetext,
-    depth, siblings,
+    depth, siblings, issamenode,
     Cursor, next!, for_each_child, @for_each_child, skip_element!, eof,
     xpath,
     h
@@ -24,6 +24,7 @@ include("xpath.jl")      # xpath over Node trees (needs Node + accessors)
 include("lazynode.jl")   # LazyNode reader (needs NodeType/Attributes; extends the generic accessors)
 include("cursor.jl")     # Cursor pull reader (needs NodeType/Attributes)
 include("flatnode.jl")   # FlatNode read-only columnar reader (needs node.jl types; checks live in parse.jl)
+include("identity.jl")   # structural ==/hash bindings + issamenode (needs all reader types above)
 include("write.jl")      # XML writer: _write_xml/_write_escaped + XML.write entry points
 include("parse.jl")      # BOM normalization, Base.read entry points, the VPA parser
 include("dtd.jl")        # DTD/DOCTYPE parsing (independent: uses only the tokenizer)

--- a/src/XML.jl
+++ b/src/XML.jl
@@ -1,7 +1,7 @@
 module XML
 
 export
-    Node, LazyNode, NodeType, Attributes,
+    Node, LazyNode, FlatNode, NodeType, Attributes,
     CData, Comment, Declaration, Document, DTD, Element, ProcessingInstruction, Text,
     nodetype, tag, attributes, value, children, children!, eachchildnode, eachattribute,
     eachelement, elements,
@@ -23,7 +23,7 @@ include("node.jl")       # NodeType, Attributes, Node + accessors/navigation/equ
 include("xpath.jl")      # xpath over Node trees (needs Node + accessors)
 include("lazynode.jl")   # LazyNode reader (needs NodeType/Attributes; extends the generic accessors)
 include("cursor.jl")     # Cursor pull reader (needs NodeType/Attributes)
-# (flatnode.jl will slot here — read-only columnar reader, planned for v0.5)
+include("flatnode.jl")   # FlatNode read-only columnar reader (needs node.jl types; checks live in parse.jl)
 include("write.jl")      # XML writer: _write_xml/_write_escaped + XML.write entry points
 include("parse.jl")      # BOM normalization, Base.read entry points, the VPA parser
 include("dtd.jl")        # DTD/DOCTYPE parsing (independent: uses only the tokenizer)

--- a/src/flatnode.jl
+++ b/src/flatnode.jl
@@ -247,14 +247,14 @@ Base.read(io::IO, ::Type{FlatNode}; wellformed::Symbol=:structural) =
     parse(String(_normalize_bom(read(io))), FlatNode; wellformed)
 
 #-----------------------------------------------------------------------------# accessors
-nodetype(n::FlatNode) = _rec(n).kind
+@inline nodetype(n::FlatNode) = _rec(n).kind
 
-function tag(n::FlatNode)
+@inline function tag(n::FlatNode)
     r = _rec(n)
     r.name_len > 0 ? _fsub(n.store, r.name_offset, r.name_len) : nothing
 end
 
-function value(n::FlatNode)
+@inline function value(n::FlatNode)
     r = _rec(n)
     r.value_offset < 0 && return nothing          # absent (empty content is offset ≥ 0, len 0)
     raw = _fsub(n.store, r.value_offset, abs(r.value_len))

--- a/src/flatnode.jl
+++ b/src/flatnode.jl
@@ -406,6 +406,8 @@ is_simple(n::FlatNode) = (r = _rec(n);
     r.kind === Element && r.attr_count == 0 && r.first_child != 0 &&
     (c = @inbounds n.store.recs[r.first_child]; c.next_sibling == 0 && (c.kind === Text || c.kind === CData)))
 
+is_simple_value(n::FlatNode) = is_simple(n) ? value(FlatNode(n.store, _rec(n).first_child)) : nothing
+
 function simple_value(n::FlatNode)
     is_simple(n) || error("`simple_value` requires a simple node: an Element with no attributes and exactly one Text or CData child. See `is_simple`.")
     value(FlatNode(n.store, _rec(n).first_child))

--- a/src/flatnode.jl
+++ b/src/flatnode.jl
@@ -63,9 +63,6 @@ struct FlatNode
     i::Int32
 end
 
-Base.:(==)(a::FlatNode, b::FlatNode) = a.store === b.store && a.i == b.i
-Base.hash(a::FlatNode, h::UInt) = hash(a.i, hash(objectid(a.store), h))
-
 @inline _rec(n::FlatNode) = @inbounds n.store.recs[n.i]
 @inline _fsub(store::FlatStore, off::Int32, len::Int32) =
     @inbounds SubString(store.source, off + 1, prevind(store.source, off + len + 1))

--- a/src/flatnode.jl
+++ b/src/flatnode.jl
@@ -24,6 +24,7 @@ struct FlatStore
     source::String
     recs::Vector{_FlatRec}            # recs[1] = the Document node
     attrs::Vector{_FlatAttr}
+    spans::Vector{NTuple{2,Int32}}    # per-record source span (start, end) — 0-based, half-open
 end
 
 """
@@ -104,15 +105,20 @@ function _flat_parse(xml::String, ::Val{W}) where {W}
         error("FlatNode stores byte offsets as Int32: source is larger than 2 GiB. Use `parse(xml, Node)`.")
     recs = _FlatRec[]
     attrs = _FlatAttr[]
+    spans = NTuple{2,Int32}[]
     sizehint!(recs, ncodeunits(xml) >> 4)
+    sizehint!(spans, ncodeunits(xml) >> 4)
     push!(recs, _FlatRec(Document, Int32(0), Int32(0), Int32(0), Int32(0), Int32(0), Int32(-1), Int32(0), Int32(0), Int32(0)))
+    push!(spans, (Int32(0), Int32(ncodeunits(xml))))
     pstack    = Int32[1]
     lastchild = Int32[0]
     K = TokenKinds
 
     cur = Int32(0)                    # record receiving ATTR_* (open element or XML declaration)
-    pend = Int32(0)                   # record awaiting its PI_CONTENT — filled in place
+    pend = Int32(0)                   # record awaiting its content / span end — patched in place
     pan_off = Int32(0); pan_len = Int32(0)   # pending attribute name
+    open_off = Int32(0)               # offset of the last COMMENT/CDATA/DOCTYPE opening marker
+    tok_end(t) = Int32(t.offset + t.ncodeunits)
 
     for token in tokenize(xml)
         k = token.kind
@@ -125,6 +131,7 @@ function _flat_parse(xml::String, ::Val{W}) where {W}
             idx = Int32(length(recs) + 1)
             p = _fattach!(recs, pstack, lastchild, idx)
             push!(recs, _FlatRec(Text, p, Int32(0), Int32(0), Int32(0), Int32(0), off, len, Int32(0), Int32(0)))
+            push!(spans, (off, off + abs(len)))
 
         elseif k === K.OPEN_TAG
             nm = tag_name(token, xml)
@@ -134,18 +141,26 @@ function _flat_parse(xml::String, ::Val{W}) where {W}
             idx = Int32(length(recs) + 1)
             p = _fattach!(recs, pstack, lastchild, idx)
             push!(recs, _FlatRec(Element, p, Int32(0), Int32(0), noff, nlen, Int32(-1), Int32(0), Int32(0), Int32(0)))
+            push!(spans, (Int32(token.offset), Int32(0)))
             push!(pstack, idx); push!(lastchild, Int32(0))
             cur = idx
 
         elseif k === K.SELF_CLOSE
+            ci = @inbounds pstack[end]
+            @inbounds spans[ci] = (spans[ci][1], tok_end(token))
             pop!(pstack); pop!(lastchild)
 
         elseif k === K.CLOSE_TAG
             close_name = tag_name(token, xml)
             length(pstack) > 1 || error("Closing tag </$close_name> with no matching open tag.")
-            open_rec = @inbounds recs[pstack[end]]
+            ci = @inbounds pstack[end]
+            open_rec = @inbounds recs[ci]
             t = _fsub_or_empty(xml, open_rec.name_offset, open_rec.name_len)
             t == close_name || error("Mismatched tags: expected </$t>, got </$close_name>.")
+            # the CLOSE_TAG token covers `</name`; the closing `>` (ETag: '</' Name S? '>')
+            # is consumed silently by the tokenizer — locate it to end the element span
+            gt = findnext(==('>'), xml, Int(tok_end(token)) + 1)
+            @inbounds spans[ci] = (spans[ci][1], gt === nothing ? tok_end(token) : Int32(gt))
             pop!(pstack); pop!(lastchild)
 
         elseif k === K.ATTR_NAME
@@ -175,7 +190,18 @@ function _flat_parse(xml::String, ::Val{W}) where {W}
             idx = Int32(length(recs) + 1)
             p = _fattach!(recs, pstack, lastchild, idx)
             push!(recs, _FlatRec(Declaration, p, Int32(0), Int32(0), Int32(0), Int32(0), Int32(-1), Int32(0), Int32(0), Int32(0)))
+            push!(spans, (Int32(token.offset), Int32(0)))
             cur = idx
+            pend = idx
+
+        elseif k === K.XML_DECL_CLOSE
+            @inbounds spans[pend] = (spans[pend][1], tok_end(token))
+
+        elseif k === K.COMMENT_OPEN || k === K.CDATA_OPEN || k === K.DOCTYPE_OPEN
+            open_off = Int32(token.offset)
+
+        elseif k === K.COMMENT_CLOSE || k === K.CDATA_CLOSE || k === K.DOCTYPE_CLOSE || k === K.PI_CLOSE
+            @inbounds spans[pend] = (spans[pend][1], tok_end(token))
 
         elseif k === K.COMMENT_CONTENT
             cmt = raw(token, xml)
@@ -186,6 +212,8 @@ function _flat_parse(xml::String, ::Val{W}) where {W}
             idx = Int32(length(recs) + 1)
             p = _fattach!(recs, pstack, lastchild, idx)
             push!(recs, _FlatRec(Comment, p, Int32(0), Int32(0), Int32(0), Int32(0), off, len, Int32(0), Int32(0)))
+            push!(spans, (open_off, Int32(0)))
+            pend = idx
 
         elseif k === K.CDATA_CONTENT
             cdata = raw(token, xml)
@@ -194,6 +222,8 @@ function _flat_parse(xml::String, ::Val{W}) where {W}
             idx = Int32(length(recs) + 1)
             p = _fattach!(recs, pstack, lastchild, idx)
             push!(recs, _FlatRec(CData, p, Int32(0), Int32(0), Int32(0), Int32(0), off, len, Int32(0), Int32(0)))
+            push!(spans, (open_off, Int32(0)))
+            pend = idx
 
         elseif k === K.DOCTYPE_CONTENT
             W !== :lenient && length(pstack) > 1 &&
@@ -202,6 +232,8 @@ function _flat_parse(xml::String, ::Val{W}) where {W}
             idx = Int32(length(recs) + 1)
             p = _fattach!(recs, pstack, lastchild, idx)
             push!(recs, _FlatRec(DTD, p, Int32(0), Int32(0), Int32(0), Int32(0), off, len, Int32(0), Int32(0)))
+            push!(spans, (open_off, Int32(0)))
+            pend = idx
 
         elseif k === K.PI_OPEN
             target = pi_target(token, xml)
@@ -211,6 +243,7 @@ function _flat_parse(xml::String, ::Val{W}) where {W}
             idx = Int32(length(recs) + 1)
             p = _fattach!(recs, pstack, lastchild, idx)
             push!(recs, _FlatRec(ProcessingInstruction, p, Int32(0), Int32(0), noff, nlen, Int32(-1), Int32(0), Int32(0), Int32(0)))
+            push!(spans, (Int32(token.offset), Int32(0)))
             pend = idx
 
         elseif k === K.PI_CONTENT
@@ -221,14 +254,14 @@ function _flat_parse(xml::String, ::Val{W}) where {W}
                 @inbounds recs[pend] = _fset_value(recs[pend], off, len)
             end
         end
-        # TAG_CLOSE / COMMENT/CDATA_OPEN+CLOSE / PI_CLOSE / XML_DECL_CLOSE / DOCTYPE_OPEN+CLOSE: no tree action
+        # TAG_CLOSE: no tree action (element spans close at CLOSE_TAG/SELF_CLOSE)
     end
 
     if length(pstack) > 1
         open_names = [_fsub_or_empty(xml, recs[i].name_offset, recs[i].name_len) for i in pstack[2:end]]
         error("Unclosed tags: $(join(open_names, ", "))")
     end
-    store = FlatStore(xml, recs, attrs)
+    store = FlatStore(xml, recs, attrs, spans)
     W !== :lenient && _check_document_wellformed(children(FlatNode(store, Int32(1))))
     FlatNode(store, Int32(1))
 end
@@ -276,6 +309,18 @@ function attributes(n::FlatNode)
         ai += Int32(1)
     end
     out
+end
+
+"""
+    sourcetext(n::FlatNode) -> SubString
+
+The node's exact raw source slice, markup included — `<tag …>…</tag>` for an element,
+`<!--…-->` for a comment, and the whole document for the Document node. Zero-copy: the
+store keeps per-record source spans.
+"""
+function sourcetext(n::FlatNode)
+    so, se = @inbounds n.store.spans[n.i]
+    _fsub(n.store, so, se - so)
 end
 
 """

--- a/src/flatnode.jl
+++ b/src/flatnode.jl
@@ -1,0 +1,416 @@
+#-----------------------------------------------------------------------------# FlatNode — read-only columnar full-DOM reader
+# The whole document is materialized ONCE into a FlatStore: one contiguous Vector of isbits
+# records with integer index links (parent / first_child / next_sibling) plus a side Vector
+# for attributes — instead of Node's per-node heap objects. Zero-copy: records hold byte
+# ranges into the retained source; text/attribute values are entity-decoded at access.
+# A FlatNode is a lightweight handle (store, index); the Document node is index 1.
+
+struct _FlatAttr                      # isbits, 16 B
+    name_offset::Int32; name_len::Int32
+    value_offset::Int32; value_len::Int32   # value_len < 0 ⇒ value carries entities (decode at access)
+end
+
+struct _FlatRec                       # isbits, no pointers
+    kind::NodeType
+    parent::Int32
+    first_child::Int32
+    next_sibling::Int32
+    name_offset::Int32; name_len::Int32     # Element tag / PI target
+    value_offset::Int32; value_len::Int32   # Text/Comment/CData/DTD/PI content; < 0 ⇒ entities
+    attr_first::Int32; attr_count::Int32
+end
+
+struct FlatStore
+    source::String
+    recs::Vector{_FlatRec}            # recs[1] = the Document node
+    attrs::Vector{_FlatAttr}
+end
+
+"""
+    FlatNode
+
+Read-only handle into a [`FlatStore`](@ref) — XML.jl's fourth reader, alongside `Node`
+(mutable DOM), `LazyNode` (pay-per-traversal) and `Cursor` (pull streaming): *`Node`'s read
+half at `Cursor`'s GC cost*.
+
+    doc = parse(xml, FlatNode)          # or read(filename, FlatNode)
+    root = only(eachelement(doc))
+    for el in eachelement(root)
+        tag(el), attributes(el), value(el)
+    end
+
+The whole document is parsed once into a contiguous columnar store (a `Vector` of isbits
+records indexing into the retained source string), so building is fast, random access is
+O(1), repeated traversals never re-decode structure, and the garbage collector sees a
+handful of arrays instead of one object per node. Text and attribute values are zero-copy
+`SubString`s, entity-decoded on access.
+
+Compared with `Node`:
+- **read-only** — no `push!`/`setindex!`; build documents with `Node` / [`h`](@ref).
+- `parent(node)` and `depth(node)` work directly (O(1) / O(depth)) — the store keeps
+  parent links, which `Node` does not.
+- `==` and `hash` are **positional identity**: two `FlatNode`s are equal iff they point at
+  the same node of the same store (compare content by converting: `Node(a) == Node(b)`).
+- retention is all-or-nothing: any live handle keeps the whole store (and source) alive.
+- documents are limited to 2 GiB / `typemax(Int32)` nodes; parse with `Node` beyond that.
+
+`Node(flatnode)` materializes a handle (and its subtree) as an ordinary mutable `Node`;
+`XML.write` accepts a `FlatNode` directly.
+"""
+struct FlatNode
+    store::FlatStore
+    i::Int32
+end
+
+Base.:(==)(a::FlatNode, b::FlatNode) = a.store === b.store && a.i == b.i
+Base.hash(a::FlatNode, h::UInt) = hash(a.i, hash(objectid(a.store), h))
+
+@inline _rec(n::FlatNode) = @inbounds n.store.recs[n.i]
+@inline _fsub(store::FlatStore, off::Int32, len::Int32) =
+    @inbounds SubString(store.source, off + 1, prevind(store.source, off + len + 1))
+
+# byte range of a SubString into its (root) parent string
+@inline _frng(s::SubString{String}) = (Int32(s.offset), Int32(s.ncodeunits))
+
+# record-update helpers (immutable records; rebuild in place)
+@inline _fset_first_child(n::_FlatRec, i::Int32) =
+    _FlatRec(n.kind, n.parent, i, n.next_sibling, n.name_offset, n.name_len, n.value_offset, n.value_len, n.attr_first, n.attr_count)
+@inline _fset_next_sibling(n::_FlatRec, i::Int32) =
+    _FlatRec(n.kind, n.parent, n.first_child, i, n.name_offset, n.name_len, n.value_offset, n.value_len, n.attr_first, n.attr_count)
+@inline _fset_value(n::_FlatRec, off::Int32, len::Int32) =
+    _FlatRec(n.kind, n.parent, n.first_child, n.next_sibling, n.name_offset, n.name_len, off, len, n.attr_first, n.attr_count)
+@inline _fadd_attr(n::_FlatRec, first::Int32) =
+    _FlatRec(n.kind, n.parent, n.first_child, n.next_sibling, n.name_offset, n.name_len, n.value_offset, n.value_len,
+             n.attr_first == 0 ? first : n.attr_first, n.attr_count + Int32(1))
+
+# wire record `idx` as the next child of the current open parent; returns the parent index
+@inline function _fattach!(recs::Vector{_FlatRec}, pstack::Vector{Int32}, lastchild::Vector{Int32}, idx::Int32)
+    p = @inbounds pstack[end]
+    lc = @inbounds lastchild[end]
+    if lc == 0
+        @inbounds recs[p] = _fset_first_child(recs[p], idx)
+    else
+        @inbounds recs[lc] = _fset_next_sibling(recs[lc], idx)
+    end
+    @inbounds lastchild[end] = idx
+    p
+end
+
+# Token-stream → FlatStore builder: the same single visibly-pushdown pass as `_parse`
+# (see parse.jl), with the same well-formedness checks at the same token points — gated by
+# `Val{W}` so :lenient pays nothing — but appending isbits records instead of heap nodes.
+function _flat_parse(xml::String, ::Val{W}) where {W}
+    ncodeunits(xml) <= typemax(Int32) ||
+        error("FlatNode stores byte offsets as Int32: source is larger than 2 GiB. Use `parse(xml, Node)`.")
+    recs = _FlatRec[]
+    attrs = _FlatAttr[]
+    sizehint!(recs, ncodeunits(xml) >> 4)
+    push!(recs, _FlatRec(Document, Int32(0), Int32(0), Int32(0), Int32(0), Int32(0), Int32(0), Int32(0), Int32(0), Int32(0)))
+    pstack    = Int32[1]
+    lastchild = Int32[0]
+    K = TokenKinds
+
+    cur = Int32(0)                    # record receiving ATTR_* (open element or XML declaration)
+    pend = Int32(0)                   # record awaiting its PI_CONTENT — filled in place
+    pan_off = Int32(0); pan_len = Int32(0)   # pending attribute name
+
+    for token in tokenize(xml)
+        k = token.kind
+        if k === K.TEXT
+            rawtext = raw(token, xml)
+            W === :strict && _check_chars_strict(rawtext)
+            W === :strict && token.has_entities && _check_charrefs_strict(rawtext)
+            off, len = _frng(rawtext)
+            token.has_entities && (len = -len)
+            idx = Int32(length(recs) + 1)
+            p = _fattach!(recs, pstack, lastchild, idx)
+            push!(recs, _FlatRec(Text, p, Int32(0), Int32(0), Int32(0), Int32(0), off, len, Int32(0), Int32(0)))
+
+        elseif k === K.OPEN_TAG
+            nm = tag_name(token, xml)
+            W !== :lenient && (isempty(nm) || !_is_name_start(first(nm))) &&
+                error("not well-formed: invalid element name \"$nm\"")
+            noff, nlen = _frng(nm)
+            idx = Int32(length(recs) + 1)
+            p = _fattach!(recs, pstack, lastchild, idx)
+            push!(recs, _FlatRec(Element, p, Int32(0), Int32(0), noff, nlen, Int32(0), Int32(0), Int32(0), Int32(0)))
+            push!(pstack, idx); push!(lastchild, Int32(0))
+            cur = idx
+
+        elseif k === K.SELF_CLOSE
+            pop!(pstack); pop!(lastchild)
+
+        elseif k === K.CLOSE_TAG
+            close_name = tag_name(token, xml)
+            length(pstack) > 1 || error("Closing tag </$close_name> with no matching open tag.")
+            open_rec = @inbounds recs[pstack[end]]
+            t = _fsub_or_empty(xml, open_rec.name_offset, open_rec.name_len)
+            t == close_name || error("Mismatched tags: expected </$t>, got </$close_name>.")
+            pop!(pstack); pop!(lastchild)
+
+        elseif k === K.ATTR_NAME
+            pan_off, pan_len = _frng(raw(token, xml))
+
+        elseif k === K.ATTR_VALUE
+            rawval = attr_value(token, xml)
+            W !== :lenient && occursin('<', rawval) && error("not well-formed: '<' in attribute value (XML 1.0 §3.1)")
+            W === :strict && _check_chars_strict(rawval)
+            W === :strict && token.has_entities && _check_charrefs_strict(rawval)
+            name = _fsub_or_empty(xml, pan_off, pan_len)
+            r = @inbounds recs[cur]
+            ai = r.attr_first
+            for _ in 1:r.attr_count
+                a = @inbounds attrs[ai]
+                _fsub_or_empty(xml, a.name_offset, a.name_len) == name && error("Duplicate attribute: $name")
+                ai += Int32(1)
+            end
+            voff, vlen = _frng(rawval)
+            token.has_entities && (vlen = -vlen)
+            push!(attrs, _FlatAttr(pan_off, pan_len, voff, vlen))
+            @inbounds recs[cur] = _fadd_attr(recs[cur], Int32(length(attrs)))
+
+        elseif k === K.XML_DECL_OPEN
+            W !== :lenient && length(pstack) > 1 &&
+                error("not well-formed: XML declaration inside element content")
+            idx = Int32(length(recs) + 1)
+            p = _fattach!(recs, pstack, lastchild, idx)
+            push!(recs, _FlatRec(Declaration, p, Int32(0), Int32(0), Int32(0), Int32(0), Int32(0), Int32(0), Int32(0), Int32(0)))
+            cur = idx
+
+        elseif k === K.COMMENT_CONTENT
+            cmt = raw(token, xml)
+            W === :strict && _check_chars_strict(cmt)
+            W === :strict && occursin("--", cmt) && error("not well-formed: \"--\" within a comment")
+            W === :strict && endswith(cmt, '-') && error("not well-formed: \"-\" immediately before \"-->\" in a comment (XML 1.0 §2.5)")
+            off, len = _frng(cmt)
+            idx = Int32(length(recs) + 1)
+            p = _fattach!(recs, pstack, lastchild, idx)
+            push!(recs, _FlatRec(Comment, p, Int32(0), Int32(0), Int32(0), Int32(0), off, len, Int32(0), Int32(0)))
+
+        elseif k === K.CDATA_CONTENT
+            cdata = raw(token, xml)
+            W === :strict && _check_chars_strict(cdata)
+            off, len = _frng(cdata)
+            idx = Int32(length(recs) + 1)
+            p = _fattach!(recs, pstack, lastchild, idx)
+            push!(recs, _FlatRec(CData, p, Int32(0), Int32(0), Int32(0), Int32(0), off, len, Int32(0), Int32(0)))
+
+        elseif k === K.DOCTYPE_CONTENT
+            W !== :lenient && length(pstack) > 1 &&
+                error("not well-formed: DOCTYPE declaration inside element content")
+            off, len = _frng(lstrip(raw(token, xml)))        # mirror _parse: lstrip'd DTD value
+            idx = Int32(length(recs) + 1)
+            p = _fattach!(recs, pstack, lastchild, idx)
+            push!(recs, _FlatRec(DTD, p, Int32(0), Int32(0), Int32(0), Int32(0), off, len, Int32(0), Int32(0)))
+
+        elseif k === K.PI_OPEN
+            target = pi_target(token, xml)
+            W === :strict && (isempty(target) || !_is_name_start(first(target))) &&
+                error("not well-formed: invalid processing-instruction target \"$target\"")
+            noff, nlen = _frng(target)
+            idx = Int32(length(recs) + 1)
+            p = _fattach!(recs, pstack, lastchild, idx)
+            push!(recs, _FlatRec(ProcessingInstruction, p, Int32(0), Int32(0), noff, nlen, Int32(0), Int32(0), Int32(0), Int32(0)))
+            pend = idx
+
+        elseif k === K.PI_CONTENT
+            content = lstrip(raw(token, xml))                # mirror _parse: lstrip'd, empty → none
+            W === :strict && _check_chars_strict(content)
+            if !isempty(content)
+                off, len = _frng(content)
+                @inbounds recs[pend] = _fset_value(recs[pend], off, len)
+            end
+        end
+        # TAG_CLOSE / COMMENT/CDATA_OPEN+CLOSE / PI_CLOSE / XML_DECL_CLOSE / DOCTYPE_OPEN+CLOSE: no tree action
+    end
+
+    if length(pstack) > 1
+        open_names = [_fsub_or_empty(xml, recs[i].name_offset, recs[i].name_len) for i in pstack[2:end]]
+        error("Unclosed tags: $(join(open_names, ", "))")
+    end
+    store = FlatStore(xml, recs, attrs)
+    W !== :lenient && _check_document_wellformed(children(FlatNode(store, Int32(1))))
+    FlatNode(store, Int32(1))
+end
+
+@inline _fsub_or_empty(source::String, off::Int32, len::Int32) =
+    len > 0 ? (@inbounds SubString(source, off + 1, prevind(source, off + len + 1))) : SubString(source, 1, 0)
+
+#-----------------------------------------------------------------------------# parse / read entry points
+Base.parse(xml::AbstractString, ::Type{FlatNode}; wellformed::Symbol=:structural) =
+    _flat_parse(_drop_bom(String(xml)), Val(wellformed))
+Base.parse(::Type{FlatNode}, xml::AbstractString; wellformed::Symbol=:structural) =
+    parse(xml, FlatNode; wellformed)
+Base.read(filename::AbstractString, ::Type{FlatNode}; wellformed::Symbol=:structural) =
+    parse(String(_normalize_bom(read(filename))), FlatNode; wellformed)
+Base.read(io::IO, ::Type{FlatNode}; wellformed::Symbol=:structural) =
+    parse(String(_normalize_bom(read(io))), FlatNode; wellformed)
+
+#-----------------------------------------------------------------------------# accessors
+nodetype(n::FlatNode) = _rec(n).kind
+
+function tag(n::FlatNode)
+    r = _rec(n)
+    r.name_len > 0 ? _fsub(n.store, r.name_offset, r.name_len) : nothing
+end
+
+function value(n::FlatNode)
+    r = _rec(n)
+    len = r.value_len
+    len == 0 && return nothing
+    raw = _fsub(n.store, r.value_offset, abs(len))
+    len < 0 ? unescape(raw) : raw
+end
+
+function attributes(n::FlatNode)
+    r = _rec(n)
+    r.attr_count == 0 && return nothing
+    out = Pair{SubString{String}, SubString{String}}[]
+    sizehint!(out, r.attr_count)
+    ai = r.attr_first
+    for _ in 1:r.attr_count
+        a = @inbounds n.store.attrs[ai]
+        name = _fsub(n.store, a.name_offset, a.name_len)
+        rawv = _fsub(n.store, a.value_offset, abs(a.value_len))
+        val = a.value_len < 0 ? _as_substring(unescape(rawv)) : rawv
+        push!(out, name => val)
+        ai += Int32(1)
+    end
+    out
+end
+
+"""
+    parent(n::FlatNode) -> FlatNode or nothing
+
+O(1) parent lookup (the flat store keeps parent links). Returns `nothing` for the
+Document node.
+"""
+function Base.parent(n::FlatNode)
+    p = _rec(n).parent
+    p == 0 ? nothing : FlatNode(n.store, p)
+end
+
+"""
+    depth(n::FlatNode) -> Int
+
+Depth of the node in its document: the Document node is 1, the root element 2, …
+O(depth), via the stored parent links.
+"""
+function depth(n::FlatNode)
+    d = 1
+    p = _rec(n).parent
+    while p != 0
+        d += 1
+        p = @inbounds n.store.recs[p].parent
+    end
+    d
+end
+
+#-----------------------------------------------------------------------------# child iteration
+struct FlatChildIterator
+    store::FlatStore
+    first::Int32
+end
+
+Base.IteratorSize(::Type{FlatChildIterator}) = Base.SizeUnknown()
+Base.eltype(::Type{FlatChildIterator}) = FlatNode
+
+function Base.iterate(it::FlatChildIterator, i::Int32 = it.first)
+    i == 0 && return nothing
+    (FlatNode(it.store, i), (@inbounds it.store.recs[i].next_sibling))
+end
+
+"""
+    eachchildnode(n::FlatNode)
+
+Lazy iterator over the children of `n`, one `FlatNode` handle at a time (no vector
+materialized). See also [`children`](@ref) and [`eachelement`](@ref).
+"""
+eachchildnode(n::FlatNode) = FlatChildIterator(n.store, _rec(n).first_child)
+
+function children(n::FlatNode)
+    nt = _rec(n).kind
+    (nt === Document || nt === Element) || return ()
+    out = FlatNode[]
+    for c in eachchildnode(n)
+        push!(out, c)
+    end
+    out
+end
+
+# eachelement's generic definition filters children(node); build on the lazy child
+# iterator instead so no intermediate Vector is materialized (same move as LazyNode's).
+eachelement(node::FlatNode) = Iterators.filter(n -> nodetype(n) === Element, eachchildnode(node))
+
+function Base.length(n::FlatNode)
+    len = 0
+    for _ in eachchildnode(n)
+        len += 1
+    end
+    len
+end
+
+function Base.getindex(n::FlatNode, i::Integer)
+    k = 0
+    for c in eachchildnode(n)
+        (k += 1) == i && return c
+    end
+    throw(BoundsError(n, i))
+end
+
+is_simple(n::FlatNode) = (r = _rec(n);
+    r.kind === Element && r.attr_count == 0 && r.first_child != 0 &&
+    (c = @inbounds n.store.recs[r.first_child]; c.next_sibling == 0 && (c.kind === Text || c.kind === CData)))
+
+function simple_value(n::FlatNode)
+    is_simple(n) || error("`simple_value` requires a simple node: an Element with no attributes and exactly one Text or CData child. See `is_simple`.")
+    value(FlatNode(n.store, _rec(n).first_child))
+end
+
+#-----------------------------------------------------------------------------# conversion / write / show
+"""
+    Node(n::FlatNode) -> Node{String}
+
+Materialize a flat handle (and its whole subtree) as an ordinary mutable `Node`, with
+decoded text and attribute values — the bridge from the read-only store to the mutable
+DOM (e.g. to edit a subtree or compare content with `==`).
+"""
+function Node(n::FlatNode)
+    r = _rec(n)
+    a = attributes(n)
+    attrs = a === nothing ? nothing : Pair{String,String}[String(k) => String(v) for (k, v) in a]
+    t = tag(n)
+    v = value(n)
+    ch = (r.kind === Document || r.kind === Element) ?
+        Node{String}[Node(c) for c in eachchildnode(n)] : nothing
+    Node{String}(r.kind, t === nothing ? nothing : String(t), attrs,
+                 v === nothing ? nothing : String(v),
+                 ch === nothing || isempty(ch) ? nothing : ch)
+end
+
+write(n::FlatNode; kw...) = write(Node(n); kw...)
+write(io::IO, n::FlatNode; kw...) = write(io, Node(n); kw...)
+write(filename::AbstractString, n::FlatNode; kw...) = write(filename, Node(n); kw...)
+
+function Base.show(io::IO, n::FlatNode)
+    r = _rec(n)
+    print(io, "FlatNode ", r.kind)
+    if r.kind === Element
+        print(io, " <", tag(n))
+        a = attributes(n)
+        if a !== nothing
+            for (k, v) in a
+                print(io, ' ', k, "=\"", v, '"')
+            end
+        end
+        print(io, '>')
+    elseif r.kind === ProcessingInstruction
+        print(io, " <?", tag(n), "?>")
+    elseif r.value_len != 0
+        v = value(n)
+        s = v === nothing ? "" : v
+        print(io, ' ', repr(first(s, 40)), ncodeunits(s) > 40 ? "…" : "")
+    end
+    nc = r.kind === Document || r.kind === Element ? length(n) : 0
+    nc > 0 && print(io, " (", nc, " children)")
+end

--- a/src/flatnode.jl
+++ b/src/flatnode.jl
@@ -34,6 +34,10 @@ Read-only handle into a [`FlatStore`](@ref) — XML.jl's fourth reader, alongsid
 (mutable DOM), `LazyNode` (pay-per-traversal) and `Cursor` (pull streaming): *`Node`'s read
 half at `Cursor`'s GC cost*.
 
+!!! warning "Experimental"
+    `FlatNode` is new and marked experimental while its usage settles in the dependent
+    ecosystem: API details may still change in a 0.4.x release. Feedback welcome in #82.
+
     doc = parse(xml, FlatNode)          # or read(filename, FlatNode)
     root = only(eachelement(doc))
     for el in eachelement(root)
@@ -50,8 +54,9 @@ Compared with `Node`:
 - **read-only** — no `push!`/`setindex!`; build documents with `Node` / [`h`](@ref).
 - `parent(node)` and `depth(node)` work directly (O(1) / O(depth)) — the store keeps
   parent links, which `Node` does not.
-- `==` and `hash` are **positional identity**: two `FlatNode`s are equal iff they point at
-  the same node of the same store (compare content by converting: `Node(a) == Node(b)`).
+- `==`/`isequal`/`hash` are **structural** (equal decoded content), like every reader —
+  cross-reader comparisons included. Positional identity — same node of the same store —
+  is [`issamenode`](@ref).
 - retention is all-or-nothing: any live handle keeps the whole store (and source) alive.
 - documents are limited to 2 GiB / `typemax(Int32)` nodes; parse with `Node` beyond that.
 

--- a/src/flatnode.jl
+++ b/src/flatnode.jl
@@ -16,7 +16,7 @@ struct _FlatRec                       # isbits, no pointers
     first_child::Int32
     next_sibling::Int32
     name_offset::Int32; name_len::Int32     # Element tag / PI target
-    value_offset::Int32; value_len::Int32   # Text/Comment/CData/DTD/PI content; < 0 ⇒ entities
+    value_offset::Int32; value_len::Int32   # content; offset == -1 ⇒ NO value (vs empty ""); len < 0 ⇒ entities
     attr_first::Int32; attr_count::Int32
 end
 
@@ -105,7 +105,7 @@ function _flat_parse(xml::String, ::Val{W}) where {W}
     recs = _FlatRec[]
     attrs = _FlatAttr[]
     sizehint!(recs, ncodeunits(xml) >> 4)
-    push!(recs, _FlatRec(Document, Int32(0), Int32(0), Int32(0), Int32(0), Int32(0), Int32(0), Int32(0), Int32(0), Int32(0)))
+    push!(recs, _FlatRec(Document, Int32(0), Int32(0), Int32(0), Int32(0), Int32(0), Int32(-1), Int32(0), Int32(0), Int32(0)))
     pstack    = Int32[1]
     lastchild = Int32[0]
     K = TokenKinds
@@ -133,7 +133,7 @@ function _flat_parse(xml::String, ::Val{W}) where {W}
             noff, nlen = _frng(nm)
             idx = Int32(length(recs) + 1)
             p = _fattach!(recs, pstack, lastchild, idx)
-            push!(recs, _FlatRec(Element, p, Int32(0), Int32(0), noff, nlen, Int32(0), Int32(0), Int32(0), Int32(0)))
+            push!(recs, _FlatRec(Element, p, Int32(0), Int32(0), noff, nlen, Int32(-1), Int32(0), Int32(0), Int32(0)))
             push!(pstack, idx); push!(lastchild, Int32(0))
             cur = idx
 
@@ -174,7 +174,7 @@ function _flat_parse(xml::String, ::Val{W}) where {W}
                 error("not well-formed: XML declaration inside element content")
             idx = Int32(length(recs) + 1)
             p = _fattach!(recs, pstack, lastchild, idx)
-            push!(recs, _FlatRec(Declaration, p, Int32(0), Int32(0), Int32(0), Int32(0), Int32(0), Int32(0), Int32(0), Int32(0)))
+            push!(recs, _FlatRec(Declaration, p, Int32(0), Int32(0), Int32(0), Int32(0), Int32(-1), Int32(0), Int32(0), Int32(0)))
             cur = idx
 
         elseif k === K.COMMENT_CONTENT
@@ -210,7 +210,7 @@ function _flat_parse(xml::String, ::Val{W}) where {W}
             noff, nlen = _frng(target)
             idx = Int32(length(recs) + 1)
             p = _fattach!(recs, pstack, lastchild, idx)
-            push!(recs, _FlatRec(ProcessingInstruction, p, Int32(0), Int32(0), noff, nlen, Int32(0), Int32(0), Int32(0), Int32(0)))
+            push!(recs, _FlatRec(ProcessingInstruction, p, Int32(0), Int32(0), noff, nlen, Int32(-1), Int32(0), Int32(0), Int32(0)))
             pend = idx
 
         elseif k === K.PI_CONTENT
@@ -256,10 +256,9 @@ end
 
 function value(n::FlatNode)
     r = _rec(n)
-    len = r.value_len
-    len == 0 && return nothing
-    raw = _fsub(n.store, r.value_offset, abs(len))
-    len < 0 ? unescape(raw) : raw
+    r.value_offset < 0 && return nothing          # absent (empty content is offset ≥ 0, len 0)
+    raw = _fsub(n.store, r.value_offset, abs(r.value_len))
+    r.value_len < 0 ? unescape(raw) : raw
 end
 
 function attributes(n::FlatNode)
@@ -406,9 +405,8 @@ function Base.show(io::IO, n::FlatNode)
         print(io, '>')
     elseif r.kind === ProcessingInstruction
         print(io, " <?", tag(n), "?>")
-    elseif r.value_len != 0
-        v = value(n)
-        s = v === nothing ? "" : v
+    elseif r.value_offset >= 0
+        s = something(value(n), "")
         print(io, ' ', repr(first(s, 40)), ncodeunits(s) > 40 ? "…" : "")
     end
     nc = r.kind === Document || r.kind === Element ? length(n) : 0

--- a/src/identity.jl
+++ b/src/identity.jl
@@ -1,0 +1,22 @@
+# Structural `==`/`hash` bindings shared by the three tree readers — and across them —
+# plus `issamenode`, the positional-identity predicate. The comparison/hash kernels live
+# in node.jl; the bindings live here because the Union below needs every reader type
+# defined first.
+
+const _TreeNode = Union{Node, LazyNode, FlatNode}
+
+Base.:(==)(a::_TreeNode, b::_TreeNode) = _structural_eq(a, b)
+Base.hash(o::_TreeNode, h::UInt) = _structural_hash(o, h)
+
+"""
+    issamenode(a, b) -> Bool
+
+Whether `a` and `b` are handles to the same node of the same parsed document — positional
+identity, which neither `==` (structural equality of decoded content) nor `===` (egal is
+content-based on immutable handles) can express.
+
+Defined for the handle readers `LazyNode` and `FlatNode`. A `Node` is a self-contained
+value with no document anchor, so positional identity does not apply to it.
+"""
+issamenode(a::FlatNode, b::FlatNode) = a.store === b.store && a.i == b.i
+issamenode(a::LazyNode, b::LazyNode) = a.data === b.data && a.token === b.token

--- a/src/node.jl
+++ b/src/node.jl
@@ -358,37 +358,45 @@ end
 #-----------------------------------------------------------------------------# equality
 # Treat `nothing` and an empty collection as equivalent so that an absent attribute /
 # children field compares equal to an explicitly empty one.
-_eq(::Nothing, ::Nothing) = true
-_eq(::Nothing, b) = isempty(b)
-_eq(a, ::Nothing) = isempty(a)
-_eq(a, b) = a == b
-
-# Attribute equality is order-insensitive per XML spec.
+# Attribute equality is order-insensitive per XML spec; an absent (`nothing`) attribute
+# set equals an empty one. Containers differ per reader (Attributes, lazy iterators,
+# decoded pairs), so collect to pairs before comparing; keys are unique by
+# well-formedness, which makes the pairwise membership test sound.
 function _attrs_eq(a, b)
-    a_empty = isnothing(a) || isempty(a)
-    b_empty = isnothing(b) || isempty(b)
+    va = isnothing(a) ? nothing : [k => v for (k, v) in a]
+    vb = isnothing(b) ? nothing : [k => v for (k, v) in b]
+    a_empty = isnothing(va) || isempty(va)
+    b_empty = isnothing(vb) || isempty(vb)
     a_empty && b_empty && return true
-    (a_empty != b_empty) && return false
-    length(a) != length(b) && return false
-    for p in a
-        p in b || return false
+    (a_empty || b_empty) && return false
+    length(va) == length(vb) || return false
+    for p in va
+        any(==(p), vb) || return false
     end
     true
 end
 
-function Base.:(==)(a::Node, b::Node)
-    a.nodetype == b.nodetype &&
-    a.tag == b.tag &&
-    _attrs_eq(a.attributes, b.attributes) &&
-    a.value == b.value &&
-    _eq(a.children, b.children)
+# Structural equality and hash over the generic accessor surface (nodetype/tag/
+# attributes/value/children), shared by every tree reader and the cross-reader case —
+# the `Base` bindings live in identity.jl, after all reader types exist. Attribute order
+# is insignificant; child order is significant; absent (`nothing`) attributes/children
+# compare and hash like empty ones.
+function _structural_eq(a, b)
+    nodetype(a) === nodetype(b) || return false
+    tag(a) == tag(b) || return false
+    _attrs_eq(attributes(a), attributes(b)) || return false
+    value(a) == value(b) || return false
+    ca, cb = children(a), children(b)
+    sa, sb = iterate(ca), iterate(cb)
+    while sa !== nothing && sb !== nothing
+        _structural_eq(sa[1], sb[1]) || return false
+        sa, sb = iterate(ca, sa[2]), iterate(cb, sb[2])
+    end
+    sa === nothing && sb === nothing
 end
 
-# Structural hash over the generic accessor surface (nodetype/tag/attributes/value/
-# children) so every reader — and the cross-reader case — can share it. Mirrors the
-# `==` rules above: attribute order is insignificant (commutative ⊻ of pair hashes;
-# duplicate keys are excluded by well-formedness), child order is significant, and
-# absent (`nothing`) attributes/children hash like empty ones.
+# Commutative ⊻ over attribute pair hashes mirrors `_attrs_eq`'s order-insensitivity;
+# duplicate keys are excluded by well-formedness.
 function _structural_hash(n, h::UInt)
     h = hash(nodetype(n), h)
     h = hash(tag(n), h)
@@ -406,8 +414,6 @@ function _structural_hash(n, h::UInt)
     end
     h
 end
-
-Base.hash(o::Node, h::UInt) = _structural_hash(o, h)
 
 #-----------------------------------------------------------------------------# indexing
 Base.getindex(o::Node, i::Integer) = children(o)[i]

--- a/src/node.jl
+++ b/src/node.jl
@@ -367,6 +367,31 @@ function Base.:(==)(a::Node, b::Node)
     _eq(a.children, b.children)
 end
 
+# Structural hash over the generic accessor surface (nodetype/tag/attributes/value/
+# children) so every reader — and the cross-reader case — can share it. Mirrors the
+# `==` rules above: attribute order is insignificant (commutative ⊻ of pair hashes;
+# duplicate keys are excluded by well-formedness), child order is significant, and
+# absent (`nothing`) attributes/children hash like empty ones.
+function _structural_hash(n, h::UInt)
+    h = hash(nodetype(n), h)
+    h = hash(tag(n), h)
+    ha = UInt(0)
+    a = attributes(n)
+    if !isnothing(a)
+        for kv in a
+            ha ⊻= hash(kv)
+        end
+    end
+    h = hash(ha, h)
+    h = hash(value(n), h)
+    for c in children(n)
+        h = _structural_hash(c, h)
+    end
+    h
+end
+
+Base.hash(o::Node, h::UInt) = _structural_hash(o, h)
+
 #-----------------------------------------------------------------------------# indexing
 Base.getindex(o::Node, i::Integer) = children(o)[i]
 Base.getindex(o::Node, ::Colon) = children(o)

--- a/src/node.jl
+++ b/src/node.jl
@@ -210,6 +210,8 @@ is_simple_value(o::Node) = is_simple(o) ? o.children[1].value : nothing
 
 #-----------------------------------------------------------------------------# tree navigation
 
+const _AMBIGUOUS_NODE_MSG = "ambiguous: the node matches multiple indistinguishable occurrences in the tree; use FlatNode for positional navigation."
+
 """
     parent(child::Node, root::Node) -> Node
 
@@ -219,26 +221,34 @@ Since `Node` does not store parent pointers, this performs a tree search from `r
 Throws an error if `child` is not found or if `child === root`.
 
 !!! warning "Value identity"
-    `Node` is an immutable value type, so the search matches by structural equality (`===`). In a
-    tree containing value-identical sibling nodes (e.g. two empty `<item/>` elements), this may
-    return the parent of the *first* match rather than the specific node passed. The same applies to
-    [`depth`](@ref), [`siblings`](@ref), and the XPath `..` axis. A path-based redesign is planned.
+    `Node` is an immutable value type, so the search matches by value (`===`). In a tree
+    containing several value-identical nodes (e.g. two empty `<item/>` elements), the
+    occurrence the caller meant cannot be determined, and an error is raised instead of
+    silently answering for the first match. The same applies to [`depth`](@ref),
+    [`siblings`](@ref), and the XPath `..` axis. `FlatNode` navigates positionally and has
+    no such ambiguity.
 """
 function Base.parent(child::Node, root::Node)
     child === root && error("Root node has no parent.")
-    result = _find_parent(child, root)
-    isnothing(result) && error("Node not found in tree.")
-    result
+    acc = Node[]
+    _find_parents!(acc, child, root)
+    isempty(acc) && error("Node not found in tree.")
+    length(acc) > 1 && error(_AMBIGUOUS_NODE_MSG)
+    acc[1]
 end
 
-# Depth-first search for `child` within `current`; returns the containing node or nothing.
-function _find_parent(child::Node, current::Node)
+# Depth-first search for occurrences of `child` within `current`, collecting each
+# occurrence's parent; stops after a second occurrence — one is a result, two is ambiguous.
+function _find_parents!(acc::Vector{Node}, child::Node, current::Node)
     for c in children(current)
-        c === child && return current
-        result = _find_parent(child, c)
-        isnothing(result) || return result
+        if c === child
+            push!(acc, current)
+            length(acc) >= 2 && return acc
+        end
+        _find_parents!(acc, child, c)
+        length(acc) >= 2 && return acc
     end
-    nothing
+    acc
 end
 
 """
@@ -247,24 +257,30 @@ end
 Return the depth of `child` within the tree rooted at `root` (root has depth 0).
 
 Since `Node` does not store parent pointers, this performs a tree search from `root`.
-Throws an error if `child` is not found in the tree.
+Throws an error if `child` is not found in the tree, or if it matches several
+value-identical occurrences (see the warning in [`parent`](@ref)).
 """
 function depth(child::Node, root::Node)
     child === root && return 0
-    result = _find_depth(child, root, 0)
-    isnothing(result) && error("Node not found in tree.")
-    result
+    acc = Int[]
+    _find_depths!(acc, child, root, 0)
+    isempty(acc) && error("Node not found in tree.")
+    length(acc) > 1 && error(_AMBIGUOUS_NODE_MSG)
+    acc[1]
 end
 
-# Depth-first search returning the depth of `child` relative to `current` (where children
-# of `current` are at depth `d + 1`), or nothing if not found.
-function _find_depth(child::Node, current::Node, d::Int)
+# Depth-first search collecting the depth of each occurrence of `child` relative to
+# `current` (children of `current` are at depth `d + 1`); stops after a second occurrence.
+function _find_depths!(acc::Vector{Int}, child::Node, current::Node, d::Int)
     for c in children(current)
-        c === child && return d + 1
-        result = _find_depth(child, c, d + 1)
-        isnothing(result) || return result
+        if c === child
+            push!(acc, d + 1)
+            length(acc) >= 2 && return acc
+        end
+        _find_depths!(acc, child, c, d + 1)
+        length(acc) >= 2 && return acc
     end
-    nothing
+    acc
 end
 
 """
@@ -273,7 +289,8 @@ end
 Return the siblings of `child` (other children of the same parent) within the tree rooted
 at `root`.  The returned vector does not include `child` itself.
 
-Throws an error if `child` is the root or is not found in the tree.
+Throws an error if `child` is the root, is not found in the tree, or matches several
+value-identical occurrences (see the warning in [`parent`](@ref)).
 """
 function siblings(child::Node, root::Node)
     p = parent(child, root)

--- a/src/xpath.jl
+++ b/src/xpath.jl
@@ -224,8 +224,11 @@ function _xpath_step(nodes::Vector{Node{S}}, token::XPathToken, root::Node{S}) w
     elseif k === XPATH_DOTDOT
         for n in nodes
             n === root && continue
-            p = _find_parent(n, root)
-            isnothing(p) || push!(result, p)
+            acc = Node[]
+            _find_parents!(acc, n, root)
+            isempty(acc) && continue
+            length(acc) > 1 && error(_AMBIGUOUS_NODE_MSG)
+            push!(result, acc[1])
         end
 
     elseif k === XPATH_TEXT_FN

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3746,6 +3746,7 @@ end
 @testset "test_w3c" begin include("test_w3c.jl") end
 @testset "test_tokenizer" begin include("test_tokenizer.jl") end
 @testset "test_cursor" begin include("test_cursor.jl") end
+@testset "test_flatnode" begin include("test_flatnode.jl") end
 
 Test.pop_testset()
 Test.finish(_ROOT_TS)   # prints the aggregated summary and throws (exit 1) if anything failed

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3747,6 +3747,7 @@ end
 @testset "test_tokenizer" begin include("test_tokenizer.jl") end
 @testset "test_cursor" begin include("test_cursor.jl") end
 @testset "test_flatnode" begin include("test_flatnode.jl") end
+@testset "test_node_identity" begin include("test_node_identity.jl") end
 
 Test.pop_testset()
 Test.finish(_ROOT_TS)   # prints the aggregated summary and throws (exit 1) if anything failed

--- a/test/test_flatnode.jl
+++ b/test/test_flatnode.jl
@@ -38,6 +38,17 @@ const RICH_XML = """<?xml version="1.0"?><!DOCTYPE root [<!ENTITY x "y">]>
     if isfile(path)
         @test flat_agrees_with_node(read(path, FlatNode), read(path, Node))
     end
+
+    # Empty content is a VALUE ("" — value_offset ≥ 0), distinct from no value (nothing,
+    # value_offset == -1). Caught by W3C parity (sun/invalid/empty.xml, oasis p15/p18).
+    empties = "<r x=\"\"><!----><![CDATA[]]><?pi?></r>"
+    fe, ne = parse(empties, FlatNode), parse(empties, Node)
+    @test flat_agrees_with_node(fe, ne)
+    rootels = children(only(eachelement(fe)))
+    @test value(rootels[1]) == "" && nodetype(rootels[1]) === XML.Comment
+    @test value(rootels[2]) == "" && nodetype(rootels[2]) === XML.CData
+    @test value(rootels[3]) === nothing && nodetype(rootels[3]) === XML.ProcessingInstruction
+    @test attributes(only(eachelement(fe))) == ["x" => ""]
 end
 
 @testset "accessor surface" begin
@@ -130,4 +141,34 @@ end
     @test simple_value(only(eachelement(read(IOBuffer(utf8_bom), FlatNode)))) == "x"
     utf16le = vcat([0xFF, 0xFE], reinterpret(UInt8, Vector{UInt16}(transcode(UInt16, "<r>x</r>"))))
     @test simple_value(only(eachelement(read(IOBuffer(utf16le), FlatNode)))) == "x"
+end
+
+# W3C conformance parity: FlatNode must agree with the Node parser on every document of
+# the pinned suite — decoded-equivalent trees on the well-formed corpus, and the exact
+# same accept/reject verdict on the not-well-formed corpus. (`valid_tests`/`notwf_tests`
+# are globals from test_w3c.jl, which runs earlier in the suite; guard for standalone runs.)
+if @isdefined(valid_tests)
+    @testset "W3C parity with the Node parser" begin
+        n_cmp = 0
+        for test in valid_tests
+            isfile(test.uri) || continue
+            n = try read(test.uri, Node; wellformed = :strict) catch; continue end
+            f = read(test.uri, FlatNode; wellformed = :strict)
+            @test flat_agrees_with_node(f, n)
+            n_cmp += 1
+        end
+        @info "W3C valid: FlatNode ≡ Node on $n_cmp documents"
+
+        n_agree = 0
+        disagreements = String[]
+        for test in notwf_tests
+            isfile(test.uri) || continue
+            rejects_node = try read(test.uri, Node; wellformed = :strict); false catch; true end
+            rejects_flat = try read(test.uri, FlatNode; wellformed = :strict); false catch; true end
+            rejects_node == rejects_flat ? (n_agree += 1) : push!(disagreements, test.id)
+        end
+        isempty(disagreements) || @warn "verdict disagreements" disagreements=first(disagreements, 20)
+        @test isempty(disagreements)
+        @info "W3C not-wf: identical verdicts on $n_agree documents"
+    end
 end

--- a/test/test_flatnode.jl
+++ b/test/test_flatnode.jl
@@ -78,10 +78,11 @@ end
     @test root[2] == els[1]
     @test_throws BoundsError root[length(root) + 1]
 
-    # is_simple/simple_value parity with Node
+    # is_simple/simple_value/is_simple_value parity with Node
     elsn = filter(c -> nodetype(c) === XML.Element, children(rootn))
     @test [is_simple(e) for e in els] == [is_simple(e) for e in elsn]
     @test simple_value(els[1]) == simple_value(elsn[1]) == "plain"
+    @test [is_simple_value(e) for e in els] == [is_simple_value(e) for e in elsn]
 
     @test occursin("Element", repr(root))                           # show smoke
 end

--- a/test/test_flatnode.jl
+++ b/test/test_flatnode.jl
@@ -1,21 +1,6 @@
-# FlatNode — the read-only columnar reader: decoded equivalence with Node, accessor
-# surface, positional identity, well-formedness parity with the Node parser.
-
-# Recursive decoded comparison: FlatNode must agree with Node{String} on kind, tag,
-# decoded value, decoded attributes, and tree shape.
-function flat_agrees_with_node(a, b)
-    nodetype(a) === nodetype(b) || return false
-    isequal(tag(a), tag(b)) || return false
-    isequal(value(a), value(b)) || return false
-    aa, ba = attributes(a), attributes(b)
-    (aa === nothing) === (ba === nothing) || return false
-    if aa !== nothing
-        [String(k) => String(v) for (k, v) in aa] == [String(k) => String(v) for (k, v) in ba] || return false
-    end
-    ca, cb = children(a), children(b)
-    length(ca) == length(cb) || return false
-    all(flat_agrees_with_node(x, y) for (x, y) in zip(ca, cb))
-end
+# FlatNode — the read-only columnar reader: decoded equivalence with Node (via the
+# structural cross-reader `==`), accessor surface, positional identity (issamenode),
+# well-formedness parity with the Node parser.
 
 const RICH_XML = """<?xml version="1.0"?><!DOCTYPE root [<!ENTITY x "y">]>
 <!-- top comment -->
@@ -31,19 +16,19 @@ const RICH_XML = """<?xml version="1.0"?><!DOCTYPE root [<!ENTITY x "y">]>
 @testset "decoded equivalence with Node" begin
     f = parse(RICH_XML, FlatNode)
     n = parse(RICH_XML, Node)
-    @test flat_agrees_with_node(f, n)
+    @test f == n
     @test XML.write(f) == XML.write(n)
 
     path = joinpath(@__DIR__, "data", "books.xml")
     if isfile(path)
-        @test flat_agrees_with_node(read(path, FlatNode), read(path, Node))
+        @test read(path, FlatNode) == read(path, Node)
     end
 
     # Empty content is a VALUE ("" — value_offset ≥ 0), distinct from no value (nothing,
     # value_offset == -1). Caught by W3C parity (sun/invalid/empty.xml, oasis p15/p18).
     empties = "<r x=\"\"><!----><![CDATA[]]><?pi?></r>"
     fe, ne = parse(empties, FlatNode), parse(empties, Node)
-    @test flat_agrees_with_node(fe, ne)
+    @test fe == ne
     rootels = children(only(eachelement(fe)))
     @test value(rootels[1]) == "" && nodetype(rootels[1]) === XML.Comment
     @test value(rootels[2]) == "" && nodetype(rootels[2]) === XML.CData
@@ -71,7 +56,7 @@ end
 
     # parent is O(1) and defined; depth counts from the Document node
     @test parent(f) === nothing
-    @test parent(root) == f && parent(els[1]) == root
+    @test issamenode(parent(root), f) && issamenode(parent(els[1]), root)
     @test depth(f) == 1 && depth(root) == 2 && depth(els[1]) == 3
 
     # indexing walks children (whitespace Text nodes included, as everywhere in v0.4)
@@ -87,17 +72,19 @@ end
     @test occursin("Element", repr(root))                           # show smoke
 end
 
-@testset "positional identity (== and hash)" begin
+@testset "structural ==/hash, positional issamenode" begin
     f = parse(RICH_XML, FlatNode)
     root = only(eachelement(f))
     els = collect(eachelement(root))
-    @test els[1] == els[1] && els[1] != els[2]
+    @test els[1] == els[1] && els[1] != els[2]      # the two <item>s differ in content
     @test hash(els[1]) != hash(els[2])
-    @test length(unique([els[1], els[1], els[2]])) == 2             # the #55 behavior, fixed here
-    # two parses of the same document are DIFFERENT stores: handles compare unequal;
-    # compare content by materializing.
+    @test length(unique([els[1], els[1], els[2]])) == 2
+    @test issamenode(els[1], els[1])
+    @test !issamenode(els[1], els[2])
+    # two parses of the same document: structurally equal, positionally distinct.
     f2 = parse(RICH_XML, FlatNode)
-    @test f != f2
+    @test f == f2
+    @test !issamenode(f, f2)
     @test Node(f) == Node(f2)
 end
 
@@ -161,7 +148,7 @@ end
 
 @testset "BOM handling" begin
     bom = "﻿<r>x</r>"
-    @test flat_agrees_with_node(parse(bom, FlatNode), parse(bom, Node))
+    @test parse(bom, FlatNode) == parse(bom, Node)
     utf8_bom = vcat([0xEF, 0xBB, 0xBF], Vector{UInt8}("<r>x</r>"))
     @test simple_value(only(eachelement(read(IOBuffer(utf8_bom), FlatNode)))) == "x"
     utf16le = vcat([0xFF, 0xFE], reinterpret(UInt8, Vector{UInt16}(transcode(UInt16, "<r>x</r>"))))
@@ -179,7 +166,7 @@ if @isdefined(valid_tests)
             isfile(test.uri) || continue
             n = try read(test.uri, Node; wellformed = :strict) catch; continue end
             f = read(test.uri, FlatNode; wellformed = :strict)
-            @test flat_agrees_with_node(f, n)
+            @test f == n
             n_cmp += 1
         end
         @info "W3C valid: FlatNode ≡ Node on $n_cmp documents"

--- a/test/test_flatnode.jl
+++ b/test/test_flatnode.jl
@@ -134,6 +134,30 @@ end
           XML.write(parse("<a/><b/>", Node;     wellformed = :lenient))
 end
 
+@testset "sourcetext (source spans)" begin
+    xml = """<?xml version="1.0"?><!DOCTYPE r [<!ENTITY x "y">]><!-- c --><r a="1">
+  <item>plain</item><![CDATA[cd]]><?pi tgt?><!----><empty/><sp ></sp >
+</r>"""
+    f  = parse(xml, FlatNode; wellformed = :lenient)
+    lz = parse(xml, LazyNode)
+
+    # exact-slice parity with LazyNode's sourcetext, top-level and inside the root
+    for (a, b) in zip(children(f), children(lz))
+        @test isequal(sourcetext(a), sourcetext(b))
+    end
+    root = only(eachelement(f))
+    rootlz = first(Iterators.filter(c -> nodetype(c) === XML.Element, children(lz)))
+    for (a, b) in zip(children(root), children(rootlz))
+        @test isequal(sourcetext(a), sourcetext(b))
+    end
+
+    @test sourcetext(f) == xml                                   # Document = whole source
+    it = first(eachelement(root))
+    @test sourcetext(it) == "<item>plain</item>"
+    # re-parsing an element's slice reproduces the subtree
+    @test Node(only(eachelement(parse(String(sourcetext(it)), FlatNode; wellformed = :lenient)))) == Node(it)
+end
+
 @testset "BOM handling" begin
     bom = "﻿<r>x</r>"
     @test flat_agrees_with_node(parse(bom, FlatNode), parse(bom, Node))

--- a/test/test_flatnode.jl
+++ b/test/test_flatnode.jl
@@ -1,0 +1,133 @@
+# FlatNode — the read-only columnar reader: decoded equivalence with Node, accessor
+# surface, positional identity, well-formedness parity with the Node parser.
+
+# Recursive decoded comparison: FlatNode must agree with Node{String} on kind, tag,
+# decoded value, decoded attributes, and tree shape.
+function flat_agrees_with_node(a, b)
+    nodetype(a) === nodetype(b) || return false
+    isequal(tag(a), tag(b)) || return false
+    isequal(value(a), value(b)) || return false
+    aa, ba = attributes(a), attributes(b)
+    (aa === nothing) === (ba === nothing) || return false
+    if aa !== nothing
+        [String(k) => String(v) for (k, v) in aa] == [String(k) => String(v) for (k, v) in ba] || return false
+    end
+    ca, cb = children(a), children(b)
+    length(ca) == length(cb) || return false
+    all(flat_agrees_with_node(x, y) for (x, y) in zip(ca, cb))
+end
+
+const RICH_XML = """<?xml version="1.0"?><!DOCTYPE root [<!ENTITY x "y">]>
+<!-- top comment -->
+<root a="1" b="two &amp; three">
+  <item>plain</item>
+  <item attr="v&lt;w">enti&amp;ty</item>
+  <empty/>
+  <![CDATA[raw &amp; cdata]]>
+  <?pi target content?>
+  mixed text &#65;
+</root>"""
+
+@testset "decoded equivalence with Node" begin
+    f = parse(RICH_XML, FlatNode)
+    n = parse(RICH_XML, Node)
+    @test flat_agrees_with_node(f, n)
+    @test XML.write(f) == XML.write(n)
+
+    path = joinpath(@__DIR__, "data", "books.xml")
+    if isfile(path)
+        @test flat_agrees_with_node(read(path, FlatNode), read(path, Node))
+    end
+end
+
+@testset "accessor surface" begin
+    f = parse(RICH_XML, FlatNode)
+    n = parse(RICH_XML, Node)
+    root  = only(eachelement(f))
+    rootn = only(eachelement(n))
+
+    @test nodetype(f) === XML.Document && nodetype(root) === XML.Element
+    @test tag(root) == "root"
+    @test length(root) == length(children(rootn))
+    @test attributes(root) == ["a" => "1", "b" => "two & three"]   # decoded at access
+
+    els = collect(eachelement(root))
+    @test [tag(e) for e in els] == ["item", "item", "empty"]
+    @test value(children(els[2])[1]) == "enti&ty"                   # decoded at access
+    @test attributes(els[2]) == ["attr" => "v<w"]
+    @test children(children(els[1])[1]) == ()                       # Text leaf: no children
+    @test attributes(els[3]) === nothing                            # <empty/>: no attributes
+
+    # parent is O(1) and defined; depth counts from the Document node
+    @test parent(f) === nothing
+    @test parent(root) == f && parent(els[1]) == root
+    @test depth(f) == 1 && depth(root) == 2 && depth(els[1]) == 3
+
+    # indexing walks children (whitespace Text nodes included, as everywhere in v0.4)
+    @test root[2] == els[1]
+    @test_throws BoundsError root[length(root) + 1]
+
+    # is_simple/simple_value parity with Node
+    elsn = filter(c -> nodetype(c) === XML.Element, children(rootn))
+    @test [is_simple(e) for e in els] == [is_simple(e) for e in elsn]
+    @test simple_value(els[1]) == simple_value(elsn[1]) == "plain"
+
+    @test occursin("Element", repr(root))                           # show smoke
+end
+
+@testset "positional identity (== and hash)" begin
+    f = parse(RICH_XML, FlatNode)
+    root = only(eachelement(f))
+    els = collect(eachelement(root))
+    @test els[1] == els[1] && els[1] != els[2]
+    @test hash(els[1]) != hash(els[2])
+    @test length(unique([els[1], els[1], els[2]])) == 2             # the #55 behavior, fixed here
+    # two parses of the same document are DIFFERENT stores: handles compare unequal;
+    # compare content by materializing.
+    f2 = parse(RICH_XML, FlatNode)
+    @test f != f2
+    @test Node(f) == Node(f2)
+end
+
+@testset "Node materialization" begin
+    f = parse(RICH_XML, FlatNode)
+    n = parse(RICH_XML, Node)
+    @test Node(f) == n
+    els  = collect(eachelement(only(eachelement(f))))
+    elsn = filter(c -> nodetype(c) === XML.Element, children(only(eachelement(n))))
+    @test Node(els[2]) == elsn[2]
+end
+
+@testset "well-formedness parity with the Node parser" begin
+    cases = [
+        ("<a><b></a>",        NamedTuple()),                # mismatched tags (ungated)
+        ("</a>",              NamedTuple()),                # close without open (ungated)
+        ("<a>",               NamedTuple()),                # unclosed tag (ungated)
+        ("<a x=\"1\" x=\"2\"/>", NamedTuple()),             # duplicate attribute (ungated)
+        ("<a/><b/>",          NamedTuple()),                # multiple roots (:structural)
+        ("top<a/>",           NamedTuple()),                # top-level text (:structural)
+        ("<a b=\"c<d\"/>",    NamedTuple()),                # '<' in attribute (:structural)
+        ("<1a/>",             NamedTuple()),                # invalid name start (:structural)
+        ("<a>&#0;</a>",       (wellformed = :strict,)),     # illegal charref (:strict)
+        ("<a><!-- x-- --></a>", (wellformed = :strict,)),   # "--" in comment (:strict)
+    ]
+    for (bad, kw) in cases
+        err_node = try parse(bad, Node; kw...); nothing catch e sprint(showerror, e) end
+        err_flat = try parse(bad, FlatNode; kw...); nothing catch e sprint(showerror, e) end
+        @test err_node !== nothing
+        @test err_node == err_flat
+    end
+    # :lenient accepts what Node's :lenient accepts
+    @test parse("<a/><b/>", FlatNode; wellformed = :lenient) isa FlatNode
+    @test XML.write(parse("<a/><b/>", FlatNode; wellformed = :lenient)) ==
+          XML.write(parse("<a/><b/>", Node;     wellformed = :lenient))
+end
+
+@testset "BOM handling" begin
+    bom = "﻿<r>x</r>"
+    @test flat_agrees_with_node(parse(bom, FlatNode), parse(bom, Node))
+    utf8_bom = vcat([0xEF, 0xBB, 0xBF], Vector{UInt8}("<r>x</r>"))
+    @test simple_value(only(eachelement(read(IOBuffer(utf8_bom), FlatNode)))) == "x"
+    utf16le = vcat([0xFF, 0xFE], reinterpret(UInt8, Vector{UInt16}(transcode(UInt16, "<r>x</r>"))))
+    @test simple_value(only(eachelement(read(IOBuffer(utf16le), FlatNode)))) == "x"
+end

--- a/test/test_node_identity.jl
+++ b/test/test_node_identity.jl
@@ -1,0 +1,93 @@
+# Node identity & structural equality (#83) and the `==`/`hash` contract (#55).
+# Semantics: `==`/`isequal`/`hash` are structural — same decoded content — for and across
+# all readers (Node, LazyNode, FlatNode); positional identity ("same node of the same
+# document") is `XML.issamenode`; search-based navigation on `Node` raises an error when
+# the argument matches several indistinguishable occurrences rather than silently
+# answering for the first one.
+
+const IDENTITY_XML = """<root a="1" b="2"><item x="1">text</item><item x="2"/><leaf/></root>"""
+
+@testset "==/hash contract on Node (#55)" begin
+    a = parse(IDENTITY_XML, Node)
+    b = parse(IDENTITY_XML, Node)
+    @test a == b
+    @test isequal(a, b)
+    @test hash(a) == hash(b)
+    @test length(unique([a, b])) == 1
+    d = Dict(a => 1)
+    d[b] = 2
+    @test length(d) == 1
+    @test b in Set([a])
+end
+
+@testset "hash respects ==-invariances" begin
+    # Attribute order is not significant for `==`, so it cannot be for `hash`.
+    p = parse("""<t a="1" b="2"/>""", Node)
+    q = parse("""<t b="2" a="1"/>""", Node)
+    @test p == q
+    @test hash(p) == hash(q)
+
+    # Child order IS significant.
+    r = parse("<t><x/><y/></t>", Node)
+    s = parse("<t><y/><x/></t>", Node)
+    @test r != s
+
+    # `==` treats absent (nothing) and empty children/attributes as equivalent; `hash`
+    # must honor the same equivalence (constructed vs parsed empty element).
+    el_c = Element("t")
+    el_p = only(elements(parse("<t/>", Node)))
+    @test el_c == el_p
+    @test hash(el_c) == hash(el_p)
+end
+
+@testset "navigation errors on indistinguishable occurrences" begin
+    # Parsed identical siblings are egal (content-based `===` on immutable fields), so a
+    # search from the root cannot tell which occurrence the caller meant.
+    twins = only(elements(parse("<a><item/><item/><z/></a>", Node)))
+    t1 = twins[1]
+    @test_throws ErrorException siblings(t1, twins)
+    @test_throws ErrorException parent(t1, twins)
+
+    nested = only(elements(parse("<a><b/><c><b/></c></a>", Node)))
+    inner_b = nested[2][1]
+    @test_throws ErrorException depth(inner_b, nested)
+
+    # Unambiguous nodes keep the current behavior.
+    uniq = only(elements(parse("<a><b/><c/></a>", Node)))
+    @test depth(uniq[1], uniq) == 1
+    @test length(siblings(uniq[1], uniq)) == 1
+    @test parent(uniq[1], uniq) == uniq
+end
+
+@testset "FlatNode and LazyNode are structural; identity is issamenode" begin
+    s2 = """<a x="1"><b>t</b><b>t</b></a>"""
+
+    f1, f2 = parse(s2, FlatNode), parse(s2, FlatNode)
+    @test f1 == f2
+    @test hash(f1) == hash(f2)
+
+    l1, l2 = parse(s2, LazyNode), parse(s2, LazyNode)
+    @test l1 == l2
+    @test hash(l1) == hash(l2)
+
+    # Twins inside one document: structurally equal, positionally distinct.
+    fb1, fb2 = elements(only(elements(f1)))
+    @test fb1 == fb2
+    @test XML.issamenode(fb1, fb1)
+    @test !XML.issamenode(fb1, fb2)
+
+    lb1, lb2 = elements(only(elements(l1)))
+    @test lb1 == lb2
+    @test XML.issamenode(lb1, lb1)
+    @test !XML.issamenode(lb1, lb2)
+end
+
+@testset "cross-reader structural equality" begin
+    n = parse(IDENTITY_XML, Node)
+    l = parse(IDENTITY_XML, LazyNode)
+    f = parse(IDENTITY_XML, FlatNode)
+    @test n == l
+    @test n == f
+    @test l == f
+    @test hash(n) == hash(l) == hash(f)
+end


### PR DESCRIPTION
Long-lived integration PR — same role #76 played for v0.4.0: every push to this branch gets the full CI matrix + the XLSX Downstream check, and this PR is the merge vehicle for the release tag.

**Retargeted: this branch now builds v0.4.2, not a v0.5.** Per the pre-1.0 convention (thanks @nhz2), FlatNode and the node-identity work are additive → patch release; `0.5.0` stays reserved for a genuinely breaking release. FlatNode ships **marked experimental** while its ecosystem usage settles. (The head branch keeps its historical `v0.5-dev` name — renaming it closes the PR, so the name stays.)

Landed so far:
- **`FlatNode`** — read-only columnar full-DOM reader (#82, merged via #84): W3C parity with the `Node` parser (decoded-equivalent trees on all 776 valid documents, identical verdicts on all 1257 not-wf), O(1) `parent`, `Node(::FlatNode)` bridge, `XML.write` support. Marked **experimental** (docstring/README/CHANGELOG) while its ecosystem usage settles.
- **Source spans + `sourcetext(::FlatNode)`** (SoA side column, zero-copy, asserted equal to `LazyNode`'s), `is_simple_value`, `@inline` accessors, and a by-regime benchmark script (`benchmarks/flatnode_bench.jl`).
- README reader-orientation table (the four readers behind one accessor set).
- **Node identity** (#83, merged via #86): structural `==`/`isequal`/`hash` for every tree reader, cross-reader included — the W3C parity check became a direct `==` against the `Node` parse; `issamenode` positional identity for the handle readers; search-based navigation (`parent`/`depth`/`siblings`/XPath `..`) raises an explicit error on indistinguishable occurrences instead of silently answering for the first match; `hash(::Node)` restores the `==`/`hash` contract (#55). CHANGELOG carries the migration notes.

Release content is complete: version bumped to 0.4.2, changelog section dated. `LazyNode` XPath (#79) moves to a v0.4.3.

Fixes #55.
