### PR TITLE
Node identity: structural ==/hash for all readers, issamenode, de-silenced navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entity-decoded on access), so building is fast, random access is O(1), and the GC sees a
   handful of arrays instead of one object per node — *`Node`'s read half at `Cursor`'s GC
   cost*. Extras over `Node`: O(1) `parent`, O(depth) 1-arg `depth`. By design: read-only,
-  whole-store retention, 2 GiB/`typemax(Int32)` limits (use `Node` beyond). `==`/`hash` on
-  `FlatNode` are positional identity (same store, same node). `Node(flatnode)` materializes
-  a handle as a mutable `Node`; `XML.write` accepts `FlatNode` directly. Same
-  well-formedness levels and error messages as the `Node` parser (#82).
+  whole-store retention, 2 GiB/`typemax(Int32)` limits (use `Node` beyond). `Node(flatnode)`
+  materializes a handle as a mutable `Node`; `XML.write` accepts `FlatNode` directly. Same
+  well-formedness levels and error messages as the `Node` parser. **Marked experimental**
+  while its usage settles in the dependent ecosystem: API details may still change in a
+  0.4.x release (#82).
+
+- **`issamenode(a, b)` — positional identity for the handle readers** (`FlatNode`: same
+  store + same index; `LazyNode`: same source object + same token): "is this the same node
+  of the same document", which neither `==` (structural equality) nor `===` (egal is
+  content-based on immutable handles) can express (#83).
+
+### Changed
+
+- **`==`/`isequal`/`hash` are structural for every tree reader, cross-reader included** —
+  same decoded nodetype/tag/attributes (order-insensitive)/value/children (in document
+  order), recursively. `Node` already compared structurally; `LazyNode` (previously the
+  egal fallback) and `FlatNode` (previously positional) now match it, and
+  `Node == LazyNode == FlatNode` holds for equal content (#83). Migration: code that used
+  `FlatNode` `==` as "same node" should use `issamenode`.
+
+- **Search-based `Node` navigation raises an error on indistinguishable occurrences**:
+  `parent`/`depth`/`siblings`/XPath `..` match by egal, which is content-based on parsed
+  immutable nodes — in a tree with several value-identical occurrences (e.g. twin
+  `<item/>` elements) they silently answered for the first match, yielding wrong depths
+  and sibling lists. Unambiguous calls are unchanged. Migration: for positional navigation
+  in such documents, use `FlatNode` (parent links, no ambiguity).
+
+### Fixed
+
+- **`hash(::Node)` restores the `==`/`hash` contract** (#55): `Node` compared structurally
+  but hashed by `objectid`, so `unique`/`Dict`/`Set` misbehaved on equal nodes.
 
 ### Internal
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ XML.jl ships four readers behind one set of accessors (`nodetype`, `tag`, `attri
 |---|---|---|---|---|
 | `Cursor` | no (nothing) | impossible (forward-only) | — | ~0 |
 | `LazyNode` | virtual | re-decode per visit (pay-per-traversal) | no | ~0 |
-| `FlatNode` | yes, compact (columnar) | O(1), paid once | no | ~0 |
+| `FlatNode` *(experimental)* | yes, compact (columnar) | O(1), paid once | no | ~0 |
 | `Node` | yes, objects | O(1), paid once | **yes** | high |
 
 Rules of thumb: one forward pass → `Cursor` · extract a little, memory-tight → `LazyNode` ·

--- a/src/XML.jl
+++ b/src/XML.jl
@@ -7,7 +7,7 @@ export
     eachelement, elements,
     foreach_attr,
     is_simple, simple_value, is_simple_value, sourcetext,
-    depth, siblings,
+    depth, siblings, issamenode,
     Cursor, next!, for_each_child, @for_each_child, skip_element!, eof,
     xpath,
     h
@@ -24,6 +24,7 @@ include("xpath.jl")      # xpath over Node trees (needs Node + accessors)
 include("lazynode.jl")   # LazyNode reader (needs NodeType/Attributes; extends the generic accessors)
 include("cursor.jl")     # Cursor pull reader (needs NodeType/Attributes)
 include("flatnode.jl")   # FlatNode read-only columnar reader (needs node.jl types; checks live in parse.jl)
+include("identity.jl")   # structural ==/hash bindings + issamenode (needs all reader types above)
 include("write.jl")      # XML writer: _write_xml/_write_escaped + XML.write entry points
 include("parse.jl")      # BOM normalization, Base.read entry points, the VPA parser
 include("dtd.jl")        # DTD/DOCTYPE parsing (independent: uses only the tokenizer)

--- a/src/flatnode.jl
+++ b/src/flatnode.jl
@@ -63,9 +63,6 @@ struct FlatNode
     i::Int32
 end
 
-Base.:(==)(a::FlatNode, b::FlatNode) = a.store === b.store && a.i == b.i
-Base.hash(a::FlatNode, h::UInt) = hash(a.i, hash(objectid(a.store), h))
-
 @inline _rec(n::FlatNode) = @inbounds n.store.recs[n.i]
 @inline _fsub(store::FlatStore, off::Int32, len::Int32) =
     @inbounds SubString(store.source, off + 1, prevind(store.source, off + len + 1))

--- a/src/flatnode.jl
+++ b/src/flatnode.jl
@@ -34,6 +34,10 @@ Read-only handle into a [`FlatStore`](@ref) — XML.jl's fourth reader, alongsid
 (mutable DOM), `LazyNode` (pay-per-traversal) and `Cursor` (pull streaming): *`Node`'s read
 half at `Cursor`'s GC cost*.
 
+!!! warning "Experimental"
+    `FlatNode` is new and marked experimental while its usage settles in the dependent
+    ecosystem: API details may still change in a 0.4.x release. Feedback welcome in #82.
+
     doc = parse(xml, FlatNode)          # or read(filename, FlatNode)
     root = only(eachelement(doc))
     for el in eachelement(root)
@@ -50,8 +54,9 @@ Compared with `Node`:
 - **read-only** — no `push!`/`setindex!`; build documents with `Node` / [`h`](@ref).
 - `parent(node)` and `depth(node)` work directly (O(1) / O(depth)) — the store keeps
   parent links, which `Node` does not.
-- `==` and `hash` are **positional identity**: two `FlatNode`s are equal iff they point at
-  the same node of the same store (compare content by converting: `Node(a) == Node(b)`).
+- `==`/`isequal`/`hash` are **structural** (equal decoded content), like every reader —
+  cross-reader comparisons included. Positional identity — same node of the same store —
+  is [`issamenode`](@ref).
 - retention is all-or-nothing: any live handle keeps the whole store (and source) alive.
 - documents are limited to 2 GiB / `typemax(Int32)` nodes; parse with `Node` beyond that.
 

--- a/src/identity.jl
+++ b/src/identity.jl
@@ -1,0 +1,22 @@
+# Structural `==`/`hash` bindings shared by the three tree readers — and across them —
+# plus `issamenode`, the positional-identity predicate. The comparison/hash kernels live
+# in node.jl; the bindings live here because the Union below needs every reader type
+# defined first.
+
+const _TreeNode = Union{Node, LazyNode, FlatNode}
+
+Base.:(==)(a::_TreeNode, b::_TreeNode) = _structural_eq(a, b)
+Base.hash(o::_TreeNode, h::UInt) = _structural_hash(o, h)
+
+"""
+    issamenode(a, b) -> Bool
+
+Whether `a` and `b` are handles to the same node of the same parsed document — positional
+identity, which neither `==` (structural equality of decoded content) nor `===` (egal is
+content-based on immutable handles) can express.
+
+Defined for the handle readers `LazyNode` and `FlatNode`. A `Node` is a self-contained
+value with no document anchor, so positional identity does not apply to it.
+"""
+issamenode(a::FlatNode, b::FlatNode) = a.store === b.store && a.i == b.i
+issamenode(a::LazyNode, b::LazyNode) = a.data === b.data && a.token === b.token

--- a/src/node.jl
+++ b/src/node.jl
@@ -358,37 +358,45 @@ end
 #-----------------------------------------------------------------------------# equality
 # Treat `nothing` and an empty collection as equivalent so that an absent attribute /
 # children field compares equal to an explicitly empty one.
-_eq(::Nothing, ::Nothing) = true
-_eq(::Nothing, b) = isempty(b)
-_eq(a, ::Nothing) = isempty(a)
-_eq(a, b) = a == b
-
-# Attribute equality is order-insensitive per XML spec.
+# Attribute equality is order-insensitive per XML spec; an absent (`nothing`) attribute
+# set equals an empty one. Containers differ per reader (Attributes, lazy iterators,
+# decoded pairs), so collect to pairs before comparing; keys are unique by
+# well-formedness, which makes the pairwise membership test sound.
 function _attrs_eq(a, b)
-    a_empty = isnothing(a) || isempty(a)
-    b_empty = isnothing(b) || isempty(b)
+    va = isnothing(a) ? nothing : [k => v for (k, v) in a]
+    vb = isnothing(b) ? nothing : [k => v for (k, v) in b]
+    a_empty = isnothing(va) || isempty(va)
+    b_empty = isnothing(vb) || isempty(vb)
     a_empty && b_empty && return true
-    (a_empty != b_empty) && return false
-    length(a) != length(b) && return false
-    for p in a
-        p in b || return false
+    (a_empty || b_empty) && return false
+    length(va) == length(vb) || return false
+    for p in va
+        any(==(p), vb) || return false
     end
     true
 end
 
-function Base.:(==)(a::Node, b::Node)
-    a.nodetype == b.nodetype &&
-    a.tag == b.tag &&
-    _attrs_eq(a.attributes, b.attributes) &&
-    a.value == b.value &&
-    _eq(a.children, b.children)
+# Structural equality and hash over the generic accessor surface (nodetype/tag/
+# attributes/value/children), shared by every tree reader and the cross-reader case —
+# the `Base` bindings live in identity.jl, after all reader types exist. Attribute order
+# is insignificant; child order is significant; absent (`nothing`) attributes/children
+# compare and hash like empty ones.
+function _structural_eq(a, b)
+    nodetype(a) === nodetype(b) || return false
+    tag(a) == tag(b) || return false
+    _attrs_eq(attributes(a), attributes(b)) || return false
+    value(a) == value(b) || return false
+    ca, cb = children(a), children(b)
+    sa, sb = iterate(ca), iterate(cb)
+    while sa !== nothing && sb !== nothing
+        _structural_eq(sa[1], sb[1]) || return false
+        sa, sb = iterate(ca, sa[2]), iterate(cb, sb[2])
+    end
+    sa === nothing && sb === nothing
 end
 
-# Structural hash over the generic accessor surface (nodetype/tag/attributes/value/
-# children) so every reader — and the cross-reader case — can share it. Mirrors the
-# `==` rules above: attribute order is insignificant (commutative ⊻ of pair hashes;
-# duplicate keys are excluded by well-formedness), child order is significant, and
-# absent (`nothing`) attributes/children hash like empty ones.
+# Commutative ⊻ over attribute pair hashes mirrors `_attrs_eq`'s order-insensitivity;
+# duplicate keys are excluded by well-formedness.
 function _structural_hash(n, h::UInt)
     h = hash(nodetype(n), h)
     h = hash(tag(n), h)
@@ -406,8 +414,6 @@ function _structural_hash(n, h::UInt)
     end
     h
 end
-
-Base.hash(o::Node, h::UInt) = _structural_hash(o, h)
 
 #-----------------------------------------------------------------------------# indexing
 Base.getindex(o::Node, i::Integer) = children(o)[i]

--- a/src/node.jl
+++ b/src/node.jl
@@ -367,6 +367,31 @@ function Base.:(==)(a::Node, b::Node)
     _eq(a.children, b.children)
 end
 
+# Structural hash over the generic accessor surface (nodetype/tag/attributes/value/
+# children) so every reader — and the cross-reader case — can share it. Mirrors the
+# `==` rules above: attribute order is insignificant (commutative ⊻ of pair hashes;
+# duplicate keys are excluded by well-formedness), child order is significant, and
+# absent (`nothing`) attributes/children hash like empty ones.
+function _structural_hash(n, h::UInt)
+    h = hash(nodetype(n), h)
+    h = hash(tag(n), h)
+    ha = UInt(0)
+    a = attributes(n)
+    if !isnothing(a)
+        for kv in a
+            ha ⊻= hash(kv)
+        end
+    end
+    h = hash(ha, h)
+    h = hash(value(n), h)
+    for c in children(n)
+        h = _structural_hash(c, h)
+    end
+    h
+end
+
+Base.hash(o::Node, h::UInt) = _structural_hash(o, h)
+
 #-----------------------------------------------------------------------------# indexing
 Base.getindex(o::Node, i::Integer) = children(o)[i]
 Base.getindex(o::Node, ::Colon) = children(o)

--- a/src/node.jl
+++ b/src/node.jl
@@ -210,6 +210,8 @@ is_simple_value(o::Node) = is_simple(o) ? o.children[1].value : nothing
 
 #-----------------------------------------------------------------------------# tree navigation
 
+const _AMBIGUOUS_NODE_MSG = "ambiguous: the node matches multiple indistinguishable occurrences in the tree; use FlatNode for positional navigation."
+
 """
     parent(child::Node, root::Node) -> Node
 
@@ -219,26 +221,34 @@ Since `Node` does not store parent pointers, this performs a tree search from `r
 Throws an error if `child` is not found or if `child === root`.
 
 !!! warning "Value identity"
-    `Node` is an immutable value type, so the search matches by structural equality (`===`). In a
-    tree containing value-identical sibling nodes (e.g. two empty `<item/>` elements), this may
-    return the parent of the *first* match rather than the specific node passed. The same applies to
-    [`depth`](@ref), [`siblings`](@ref), and the XPath `..` axis. A path-based redesign is planned.
+    `Node` is an immutable value type, so the search matches by value (`===`). In a tree
+    containing several value-identical nodes (e.g. two empty `<item/>` elements), the
+    occurrence the caller meant cannot be determined, and an error is raised instead of
+    silently answering for the first match. The same applies to [`depth`](@ref),
+    [`siblings`](@ref), and the XPath `..` axis. `FlatNode` navigates positionally and has
+    no such ambiguity.
 """
 function Base.parent(child::Node, root::Node)
     child === root && error("Root node has no parent.")
-    result = _find_parent(child, root)
-    isnothing(result) && error("Node not found in tree.")
-    result
+    acc = Node[]
+    _find_parents!(acc, child, root)
+    isempty(acc) && error("Node not found in tree.")
+    length(acc) > 1 && error(_AMBIGUOUS_NODE_MSG)
+    acc[1]
 end
 
-# Depth-first search for `child` within `current`; returns the containing node or nothing.
-function _find_parent(child::Node, current::Node)
+# Depth-first search for occurrences of `child` within `current`, collecting each
+# occurrence's parent; stops after a second occurrence — one is a result, two is ambiguous.
+function _find_parents!(acc::Vector{Node}, child::Node, current::Node)
     for c in children(current)
-        c === child && return current
-        result = _find_parent(child, c)
-        isnothing(result) || return result
+        if c === child
+            push!(acc, current)
+            length(acc) >= 2 && return acc
+        end
+        _find_parents!(acc, child, c)
+        length(acc) >= 2 && return acc
     end
-    nothing
+    acc
 end
 
 """
@@ -247,24 +257,30 @@ end
 Return the depth of `child` within the tree rooted at `root` (root has depth 0).
 
 Since `Node` does not store parent pointers, this performs a tree search from `root`.
-Throws an error if `child` is not found in the tree.
+Throws an error if `child` is not found in the tree, or if it matches several
+value-identical occurrences (see the warning in [`parent`](@ref)).
 """
 function depth(child::Node, root::Node)
     child === root && return 0
-    result = _find_depth(child, root, 0)
-    isnothing(result) && error("Node not found in tree.")
-    result
+    acc = Int[]
+    _find_depths!(acc, child, root, 0)
+    isempty(acc) && error("Node not found in tree.")
+    length(acc) > 1 && error(_AMBIGUOUS_NODE_MSG)
+    acc[1]
 end
 
-# Depth-first search returning the depth of `child` relative to `current` (where children
-# of `current` are at depth `d + 1`), or nothing if not found.
-function _find_depth(child::Node, current::Node, d::Int)
+# Depth-first search collecting the depth of each occurrence of `child` relative to
+# `current` (children of `current` are at depth `d + 1`); stops after a second occurrence.
+function _find_depths!(acc::Vector{Int}, child::Node, current::Node, d::Int)
     for c in children(current)
-        c === child && return d + 1
-        result = _find_depth(child, c, d + 1)
-        isnothing(result) || return result
+        if c === child
+            push!(acc, d + 1)
+            length(acc) >= 2 && return acc
+        end
+        _find_depths!(acc, child, c, d + 1)
+        length(acc) >= 2 && return acc
     end
-    nothing
+    acc
 end
 
 """
@@ -273,7 +289,8 @@ end
 Return the siblings of `child` (other children of the same parent) within the tree rooted
 at `root`.  The returned vector does not include `child` itself.
 
-Throws an error if `child` is the root or is not found in the tree.
+Throws an error if `child` is the root, is not found in the tree, or matches several
+value-identical occurrences (see the warning in [`parent`](@ref)).
 """
 function siblings(child::Node, root::Node)
     p = parent(child, root)

--- a/src/xpath.jl
+++ b/src/xpath.jl
@@ -224,8 +224,11 @@ function _xpath_step(nodes::Vector{Node{S}}, token::XPathToken, root::Node{S}) w
     elseif k === XPATH_DOTDOT
         for n in nodes
             n === root && continue
-            p = _find_parent(n, root)
-            isnothing(p) || push!(result, p)
+            acc = Node[]
+            _find_parents!(acc, n, root)
+            isempty(acc) && continue
+            length(acc) > 1 && error(_AMBIGUOUS_NODE_MSG)
+            push!(result, acc[1])
         end
 
     elseif k === XPATH_TEXT_FN

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3747,6 +3747,7 @@ end
 @testset "test_tokenizer" begin include("test_tokenizer.jl") end
 @testset "test_cursor" begin include("test_cursor.jl") end
 @testset "test_flatnode" begin include("test_flatnode.jl") end
+@testset "test_node_identity" begin include("test_node_identity.jl") end
 
 Test.pop_testset()
 Test.finish(_ROOT_TS)   # prints the aggregated summary and throws (exit 1) if anything failed

--- a/test/test_flatnode.jl
+++ b/test/test_flatnode.jl
@@ -1,21 +1,6 @@
-# FlatNode — the read-only columnar reader: decoded equivalence with Node, accessor
-# surface, positional identity, well-formedness parity with the Node parser.
-
-# Recursive decoded comparison: FlatNode must agree with Node{String} on kind, tag,
-# decoded value, decoded attributes, and tree shape.
-function flat_agrees_with_node(a, b)
-    nodetype(a) === nodetype(b) || return false
-    isequal(tag(a), tag(b)) || return false
-    isequal(value(a), value(b)) || return false
-    aa, ba = attributes(a), attributes(b)
-    (aa === nothing) === (ba === nothing) || return false
-    if aa !== nothing
-        [String(k) => String(v) for (k, v) in aa] == [String(k) => String(v) for (k, v) in ba] || return false
-    end
-    ca, cb = children(a), children(b)
-    length(ca) == length(cb) || return false
-    all(flat_agrees_with_node(x, y) for (x, y) in zip(ca, cb))
-end
+# FlatNode — the read-only columnar reader: decoded equivalence with Node (via the
+# structural cross-reader `==`), accessor surface, positional identity (issamenode),
+# well-formedness parity with the Node parser.
 
 const RICH_XML = """<?xml version="1.0"?><!DOCTYPE root [<!ENTITY x "y">]>
 <!-- top comment -->
@@ -31,19 +16,19 @@ const RICH_XML = """<?xml version="1.0"?><!DOCTYPE root [<!ENTITY x "y">]>
 @testset "decoded equivalence with Node" begin
     f = parse(RICH_XML, FlatNode)
     n = parse(RICH_XML, Node)
-    @test flat_agrees_with_node(f, n)
+    @test f == n
     @test XML.write(f) == XML.write(n)
 
     path = joinpath(@__DIR__, "data", "books.xml")
     if isfile(path)
-        @test flat_agrees_with_node(read(path, FlatNode), read(path, Node))
+        @test read(path, FlatNode) == read(path, Node)
     end
 
     # Empty content is a VALUE ("" — value_offset ≥ 0), distinct from no value (nothing,
     # value_offset == -1). Caught by W3C parity (sun/invalid/empty.xml, oasis p15/p18).
     empties = "<r x=\"\"><!----><![CDATA[]]><?pi?></r>"
     fe, ne = parse(empties, FlatNode), parse(empties, Node)
-    @test flat_agrees_with_node(fe, ne)
+    @test fe == ne
     rootels = children(only(eachelement(fe)))
     @test value(rootels[1]) == "" && nodetype(rootels[1]) === XML.Comment
     @test value(rootels[2]) == "" && nodetype(rootels[2]) === XML.CData
@@ -71,7 +56,7 @@ end
 
     # parent is O(1) and defined; depth counts from the Document node
     @test parent(f) === nothing
-    @test parent(root) == f && parent(els[1]) == root
+    @test issamenode(parent(root), f) && issamenode(parent(els[1]), root)
     @test depth(f) == 1 && depth(root) == 2 && depth(els[1]) == 3
 
     # indexing walks children (whitespace Text nodes included, as everywhere in v0.4)
@@ -87,17 +72,19 @@ end
     @test occursin("Element", repr(root))                           # show smoke
 end
 
-@testset "positional identity (== and hash)" begin
+@testset "structural ==/hash, positional issamenode" begin
     f = parse(RICH_XML, FlatNode)
     root = only(eachelement(f))
     els = collect(eachelement(root))
-    @test els[1] == els[1] && els[1] != els[2]
+    @test els[1] == els[1] && els[1] != els[2]      # the two <item>s differ in content
     @test hash(els[1]) != hash(els[2])
-    @test length(unique([els[1], els[1], els[2]])) == 2             # the #55 behavior, fixed here
-    # two parses of the same document are DIFFERENT stores: handles compare unequal;
-    # compare content by materializing.
+    @test length(unique([els[1], els[1], els[2]])) == 2
+    @test issamenode(els[1], els[1])
+    @test !issamenode(els[1], els[2])
+    # two parses of the same document: structurally equal, positionally distinct.
     f2 = parse(RICH_XML, FlatNode)
-    @test f != f2
+    @test f == f2
+    @test !issamenode(f, f2)
     @test Node(f) == Node(f2)
 end
 
@@ -161,7 +148,7 @@ end
 
 @testset "BOM handling" begin
     bom = "﻿<r>x</r>"
-    @test flat_agrees_with_node(parse(bom, FlatNode), parse(bom, Node))
+    @test parse(bom, FlatNode) == parse(bom, Node)
     utf8_bom = vcat([0xEF, 0xBB, 0xBF], Vector{UInt8}("<r>x</r>"))
     @test simple_value(only(eachelement(read(IOBuffer(utf8_bom), FlatNode)))) == "x"
     utf16le = vcat([0xFF, 0xFE], reinterpret(UInt8, Vector{UInt16}(transcode(UInt16, "<r>x</r>"))))
@@ -179,7 +166,7 @@ if @isdefined(valid_tests)
             isfile(test.uri) || continue
             n = try read(test.uri, Node; wellformed = :strict) catch; continue end
             f = read(test.uri, FlatNode; wellformed = :strict)
-            @test flat_agrees_with_node(f, n)
+            @test f == n
             n_cmp += 1
         end
         @info "W3C valid: FlatNode ≡ Node on $n_cmp documents"

--- a/test/test_node_identity.jl
+++ b/test/test_node_identity.jl
@@ -1,0 +1,93 @@
+# Node identity & structural equality (#83) and the `==`/`hash` contract (#55).
+# Semantics: `==`/`isequal`/`hash` are structural — same decoded content — for and across
+# all readers (Node, LazyNode, FlatNode); positional identity ("same node of the same
+# document") is `XML.issamenode`; search-based navigation on `Node` raises an error when
+# the argument matches several indistinguishable occurrences rather than silently
+# answering for the first one.
+
+const IDENTITY_XML = """<root a="1" b="2"><item x="1">text</item><item x="2"/><leaf/></root>"""
+
+@testset "==/hash contract on Node (#55)" begin
+    a = parse(IDENTITY_XML, Node)
+    b = parse(IDENTITY_XML, Node)
+    @test a == b
+    @test isequal(a, b)
+    @test hash(a) == hash(b)
+    @test length(unique([a, b])) == 1
+    d = Dict(a => 1)
+    d[b] = 2
+    @test length(d) == 1
+    @test b in Set([a])
+end
+
+@testset "hash respects ==-invariances" begin
+    # Attribute order is not significant for `==`, so it cannot be for `hash`.
+    p = parse("""<t a="1" b="2"/>""", Node)
+    q = parse("""<t b="2" a="1"/>""", Node)
+    @test p == q
+    @test hash(p) == hash(q)
+
+    # Child order IS significant.
+    r = parse("<t><x/><y/></t>", Node)
+    s = parse("<t><y/><x/></t>", Node)
+    @test r != s
+
+    # `==` treats absent (nothing) and empty children/attributes as equivalent; `hash`
+    # must honor the same equivalence (constructed vs parsed empty element).
+    el_c = Element("t")
+    el_p = only(elements(parse("<t/>", Node)))
+    @test el_c == el_p
+    @test hash(el_c) == hash(el_p)
+end
+
+@testset "navigation errors on indistinguishable occurrences" begin
+    # Parsed identical siblings are egal (content-based `===` on immutable fields), so a
+    # search from the root cannot tell which occurrence the caller meant.
+    twins = only(elements(parse("<a><item/><item/><z/></a>", Node)))
+    t1 = twins[1]
+    @test_throws ErrorException siblings(t1, twins)
+    @test_throws ErrorException parent(t1, twins)
+
+    nested = only(elements(parse("<a><b/><c><b/></c></a>", Node)))
+    inner_b = nested[2][1]
+    @test_throws ErrorException depth(inner_b, nested)
+
+    # Unambiguous nodes keep the current behavior.
+    uniq = only(elements(parse("<a><b/><c/></a>", Node)))
+    @test depth(uniq[1], uniq) == 1
+    @test length(siblings(uniq[1], uniq)) == 1
+    @test parent(uniq[1], uniq) == uniq
+end
+
+@testset "FlatNode and LazyNode are structural; identity is issamenode" begin
+    s2 = """<a x="1"><b>t</b><b>t</b></a>"""
+
+    f1, f2 = parse(s2, FlatNode), parse(s2, FlatNode)
+    @test f1 == f2
+    @test hash(f1) == hash(f2)
+
+    l1, l2 = parse(s2, LazyNode), parse(s2, LazyNode)
+    @test l1 == l2
+    @test hash(l1) == hash(l2)
+
+    # Twins inside one document: structurally equal, positionally distinct.
+    fb1, fb2 = elements(only(elements(f1)))
+    @test fb1 == fb2
+    @test XML.issamenode(fb1, fb1)
+    @test !XML.issamenode(fb1, fb2)
+
+    lb1, lb2 = elements(only(elements(l1)))
+    @test lb1 == lb2
+    @test XML.issamenode(lb1, lb1)
+    @test !XML.issamenode(lb1, lb2)
+end
+
+@testset "cross-reader structural equality" begin
+    n = parse(IDENTITY_XML, Node)
+    l = parse(IDENTITY_XML, LazyNode)
+    f = parse(IDENTITY_XML, FlatNode)
+    @test n == l
+    @test n == f
+    @test l == f
+    @test hash(n) == hash(l) == hash(f)
+end


### PR DESCRIPTION
Implements the node-identity design (#83) and fixes #55. Targets the `v0.5-dev` integration branch — historical name only: it builds **v0.4.2** (see #85).

- **`hash(::Node)`** (#55): `Node` compared structurally but hashed by `objectid`, so `unique`/`Dict`/`Set` misbehaved on equal nodes. A single structural kernel over the generic accessor surface (nodetype/tag/attributes/value/children) now backs `==`/`isequal`/`hash`.
- **Every tree reader is structural, cross-reader included**: `LazyNode` (previously the egal fallback) and `FlatNode` (previously positional) align with `Node`, and `Node == LazyNode == FlatNode` holds for equal decoded content. The W3C parity check (776 valid documents) becomes a direct `==` against the `Node` parse.
- **`issamenode(a, b)`**: positional identity for the handle readers (`FlatNode`: same store + same index; `LazyNode`: same source object + same token) — "same node of the same document", which neither `==` nor `===` (egal is content-based on immutable handles) can express.
- **Search-based `Node` navigation errors on indistinguishable occurrences**: `parent`/`depth`/`siblings`/XPath `..` silently answered for the first egal match (wrong depths and sibling lists on documents with value-identical twins); they now raise an explicit error pointing at `FlatNode` for positional navigation. Unambiguous calls are unchanged.
- **FlatNode marked experimental** (docstring, README, CHANGELOG) while its ecosystem usage settles, per the discussion in #85; CHANGELOG carries the migration notes.

Adds `test/test_node_identity.jl` (31 tests: ==/hash contract, hash invariances, navigation ambiguity, reader alignment, cross-reader equality). Full suite: 3415/3415.

Fixes #55.
