### PR TITLE
Cursor entry points: `parse(str, Cursor)`, `read(filename, Cursor)`, `read(io, Cursor)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to XML.jl will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`parse(str, Cursor)`, `read(filename, Cursor)`, `read(io, Cursor)`** — `Cursor` gains the
+  tree readers' entry points: same argument order, and the `read` forms apply the same
+  byte-level BOM normalization (UTF-8 BOM strip, UTF-16 LE/BE transcoding; a BOM-less UTF-16
+  file now gets the named §4.3.3 error instead of a tokenizer error). `Cursor(str)` and
+  `parse(Cursor, str)` are unchanged (#89).
+
 ## [0.4.2] - 2026-07-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`parse(str, Cursor)`, `read(filename, Cursor)`, `read(io, Cursor)`** — `Cursor` gains the
   tree readers' entry points: same argument order, and the `read` forms apply the same
   byte-level BOM normalization (UTF-8 BOM strip, UTF-16 LE/BE transcoding; a BOM-less UTF-16
-  file now gets the named §4.3.3 error instead of a tokenizer error). `Cursor(str)` and
-  `parse(Cursor, str)` are unchanged (#89).
+  file now gets the explicit `"UTF-16 without a BOM is not well-formed (XML 1.0 §4.3.3)"`
+  error instead of a cryptic tokenizer one). `Cursor(str)` and `parse(Cursor, str)` are
+  unchanged (#89).
 
 ## [0.4.2] - 2026-07-16
 

--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -30,11 +30,15 @@ end
 
 """
     Cursor(data::AbstractString)
-    parse(Cursor, data::AbstractString)
+    parse(data::AbstractString, Cursor)
+    read(filename::AbstractString, Cursor)
+    read(io::IO, Cursor)
 
 A forward, in-place [`StAX`-style] pull cursor over the XML `data`. Advance it
 with [`next!`](@ref); read the current position with [`nodetype`](@ref),
 [`tag`](@ref), [`value`](@ref), [`attributes`](@ref), [`depth`](@ref).
+(`parse(Cursor, data)` also works.) The `read` forms apply the same byte-level
+BOM normalization as the tree readers: UTF-8 BOM strip, UTF-16 LE/BE transcoding.
 
 The cursor is a single mutable object reused across the whole walk. See the
 aliasing-contract note on [`next!`](@ref).

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -25,6 +25,13 @@ end
 Base.read(filename::AbstractString, ::Type{Node}; wellformed::Symbol=:structural) = parse(String(_normalize_bom(read(filename))), Node; wellformed)
 Base.read(io::IO, ::Type{Node}; wellformed::Symbol=:structural) = parse(String(_normalize_bom(read(io))), Node; wellformed)
 
+# Cursor shares the tree readers' entry points (#89): same argument order, same byte-level
+# BOM normalization. The Cursor(str) constructor alone only drops an already-decoded U+FEFF,
+# so a UTF-16 file needs this path (like read(_, Node)) to be transcoded.
+Base.read(filename::AbstractString, ::Type{Cursor}) = Cursor(String(_normalize_bom(read(filename))))
+Base.read(io::IO, ::Type{Cursor}) = Cursor(String(_normalize_bom(read(io))))
+Base.parse(xml::AbstractString, ::Type{Cursor}) = Cursor(String(xml))
+
 #-----------------------------------------------------------------------------# parse
 # A leading U+FEFF (BOM as a character) isn't content — drop it so a BOM'd in-memory string
 # parses cleanly. (The read path strips the BOM bytes via _normalize_bom; this covers

--- a/test/test_cursor.jl
+++ b/test/test_cursor.jl
@@ -272,4 +272,48 @@ using XML: Cursor, next!, for_each_child, @for_each_child, skip_element!, eof, n
         c = at_v("<r><v>9</v></r>"); is_simple_value(c)
         @test String(tag(c)) == "v" && is_simple_value(c) == "9"
     end
+
+    @testset "entry points align with the tree readers (#89)" begin
+        xml = """<?xml version="1.0"?><root a="é"><child>texte</child></root>"""
+        eltags(cur) = (ts = String[];
+                       while next!(cur) !== nothing
+                           nodetype(cur) === XML.Element && push!(ts, String(tag(cur)))
+                       end;
+                       ts)
+
+        # reader-second parse, like the other readers
+        @test eltags(parse(xml, Cursor)) == eltags(Cursor(xml)) == ["root", "child"]
+
+        # read from a stream
+        @test eltags(read(IOBuffer(xml), Cursor)) == ["root", "child"]
+
+        # read from a file: same acceptance as read(filename, Node) — BOM handling included
+        # (UTF-8 BOM strip; UTF-16 LE/BE transcoding, which the Cursor(str) constructor's
+        # decoded-U+FEFF drop alone cannot provide)
+        dir = mktempdir()
+        u16 = transcode(UInt16, xml)
+        variants = ["utf8_plain" => Vector{UInt8}(xml),
+                    "utf8_bom"   => vcat([0xEF, 0xBB, 0xBF], Vector{UInt8}(xml)),
+                    "utf16_le"   => collect(reinterpret(UInt8, vcat(UInt16(0xFEFF), u16))),
+                    "utf16_be"   => collect(reinterpret(UInt8, bswap.(vcat(UInt16(0xFEFF), u16))))]
+        for (name, bytes) in variants
+            f = joinpath(dir, name * ".xml")
+            write(f, bytes)
+            cur = read(f, Cursor)
+            seen = String[]
+            aval = nothing
+            while next!(cur) !== nothing
+                nodetype(cur) === XML.Element || continue
+                push!(seen, String(tag(cur)))
+                tag(cur) == "root" && (aval = String(attributes(cur)["a"]))
+            end
+            @test seen == ["root", "child"]
+            @test aval == "é"
+        end
+
+        # BOM-less UTF-16: the named §4.3.3 diagnostic, not a tokenizer error
+        nobom = joinpath(dir, "utf16_nobom.xml")
+        write(nobom, collect(reinterpret(UInt8, u16)))
+        @test_throws "UTF-16 without a BOM" read(nobom, Cursor)
+    end
 end


### PR DESCRIPTION
Fixes #89: `Cursor` gains the tree readers' entry points — `parse(str, Cursor)`, `read(filename, Cursor)`, `read(io, Cursor)` — so every reader accepts the same calls, with the reader as the second argument.

The `read` forms route through the same byte-level BOM normalization as `read(_, Node)`: UTF-8 BOM strip and UTF-16 LE/BE transcoding. The `Cursor(str)` constructor alone only drops an already-decoded U+FEFF, so a UTF-16 file — legal XML, per [XML 1.0 §4.3.3 "Character Encoding in Entities"](https://www.w3.org/TR/xml/#charencoding) — previously worked through `read(file, Node)` but derailed the tokenizer through `Cursor(read(file, String))`; it now parses identically through `read(file, Cursor)`. And a BOM-less UTF-16 file gets the explicit `"UTF-16 without a BOM is not well-formed (XML 1.0 §4.3.3)"` error instead of a cryptic tokenizer one.

`Cursor(str)`, `Cursor(str, startpos)` and the reader-first `parse(Cursor, str)` are unchanged.

Tests: an entry-points testset in `test_cursor.jl` — reader-second `parse` equivalence, `read` from a stream, and `read` from files in four encodings (plain UTF-8, UTF-8+BOM, UTF-16 LE, UTF-16 BE — tag walk and a non-ASCII attribute value asserted identical), plus the named-diagnostic assertion for BOM-less UTF-16. Written red-first against #89.