### PR TITLE
`sourcespan` and `splicetext`: source positions and safe splicing for the two handle readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   splice around. O(1) on `FlatNode` (answered from the stored per-record spans). For
   consumers that need a node's *position* rather than its text — verbatim excision and
   splicing without reaching into reader internals (#92).
+- **`splicetext(n, replacement = "")`** on the same two readers: the document source with
+  the node's own text replaced — excised entirely by default. The packaged, multi-byte-safe
+  form of the `sourcespan` splice (#92).
 
 - **`parse(str, Cursor)`, `read(filename, Cursor)`, `read(io, Cursor)`** — `Cursor` gains the
   tree readers' entry points: same argument order, and the `read` forms apply the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`sourcespan(n) -> UnitRange{Int}`** on the two source-retaining readers (`LazyNode`,
+  `FlatNode`): the range of *valid character indices* the node's original source text
+  occupies, with the invariant `sourcetext(n) == SubString(source, sourcespan(n))` — the
+  library does the `prevind` computation, so multi-byte boundaries are safe to slice and
+  splice around. O(1) on `FlatNode` (answered from the stored per-record spans). For
+  consumers that need a node's *position* rather than its text — verbatim excision and
+  splicing without reaching into reader internals (#92).
+
 - **`parse(str, Cursor)`, `read(filename, Cursor)`, `read(io, Cursor)`** — `Cursor` gains the
   tree readers' entry points: same argument order, and the `read` forms apply the same
   byte-level BOM normalization (UTF-8 BOM strip, UTF-16 LE/BE transcoding; a BOM-less UTF-16

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ For streaming and high-throughput workloads, several extra accessors avoid mater
 
 ```julia
 sourcetext(n)               # zero-copy SubString view of the node's raw source bytes
+sourcespan(n)               # where that text lives: a range of valid character indices
 eachchildnode(n)            # lazy iterator over children — no Vector allocation
 children!(buf, n)           # collect children into a reusable buffer
 eachattribute(n)            # lazy iterator over attribute name=>value pairs
@@ -289,7 +290,7 @@ for el in eachelement(root)
 end
 ```
 
-Same read-only accessor surface as the other readers, including `sourcetext(node)` — the zero-copy `SubString` of a node's original source text, available on the two readers that retain the source (`FlatNode`, `LazyNode`) and not on `Node`. By design: read-only — creating or modifying documents is `Node`'s job; any live handle retains the whole store and source string; documents are limited to 2 GiB. `Node(flatnode)` materializes a handle (and its subtree) as a mutable `Node`; `XML.write` accepts a `FlatNode` directly. Positional identity — "same node of the same document" — is `issamenode(a, b)`, defined like `sourcetext` for the two handle readers (`FlatNode`, `LazyNode`); it does not apply to `Node`, a self-contained value with no document anchor.
+Same read-only accessor surface as the other readers, including `sourcetext(node)` — the zero-copy `SubString` of a node's original source text — and its positional counterpart `sourcespan(node)`, the range of valid character indices that text occupies (O(1) here, from the stored spans); both are available on the two readers that retain the source (`FlatNode`, `LazyNode`) and not on `Node`. By design: read-only — creating or modifying documents is `Node`'s job; any live handle retains the whole store and source string; documents are limited to 2 GiB. `Node(flatnode)` materializes a handle (and its subtree) as a mutable `Node`; `XML.write` accepts a `FlatNode` directly. Positional identity — "same node of the same document" — is `issamenode(a, b)`, defined like `sourcetext` for the two handle readers (`FlatNode`, `LazyNode`); it does not apply to `Node`, a self-contained value with no document anchor.
 
 > **Experimental** — new in v0.4.2: API details may still change in a 0.4.x release while ecosystem usage settles. Feedback welcome on the [issue tracker](https://github.com/JuliaData/XML.jl/issues).
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ For streaming and high-throughput workloads, several extra accessors avoid mater
 ```julia
 sourcetext(n)               # zero-copy SubString view of the node's raw source bytes
 sourcespan(n)               # where that text lives: a range of valid character indices
+splicetext(n, repl)         # the document text with this node's text replaced ("" default)
 eachchildnode(n)            # lazy iterator over children — no Vector allocation
 children!(buf, n)           # collect children into a reusable buffer
 eachattribute(n)            # lazy iterator over attribute name=>value pairs
@@ -290,7 +291,7 @@ for el in eachelement(root)
 end
 ```
 
-Same read-only accessor surface as the other readers, including `sourcetext(node)` — the zero-copy `SubString` of a node's original source text — and its positional counterpart `sourcespan(node)`, the range of valid character indices that text occupies (O(1) here, from the stored spans); both are available on the two readers that retain the source (`FlatNode`, `LazyNode`) and not on `Node`. By design: read-only — creating or modifying documents is `Node`'s job; any live handle retains the whole store and source string; documents are limited to 2 GiB. `Node(flatnode)` materializes a handle (and its subtree) as a mutable `Node`; `XML.write` accepts a `FlatNode` directly. Positional identity — "same node of the same document" — is `issamenode(a, b)`, defined like `sourcetext` for the two handle readers (`FlatNode`, `LazyNode`); it does not apply to `Node`, a self-contained value with no document anchor.
+Same read-only accessor surface as the other readers, including `sourcetext(node)` — the zero-copy `SubString` of a node's original source text — its positional counterpart `sourcespan(node)`, the range of valid character indices that text occupies (O(1) here, from the stored spans), and `splicetext(node, replacement)` — the document source with that text replaced; all three are available on the two readers that retain the source (`FlatNode`, `LazyNode`) and not on `Node`. By design: read-only — creating or modifying documents is `Node`'s job; any live handle retains the whole store and source string; documents are limited to 2 GiB. `Node(flatnode)` materializes a handle (and its subtree) as a mutable `Node`; `XML.write` accepts a `FlatNode` directly. Positional identity — "same node of the same document" — is `issamenode(a, b)`, defined like `sourcetext` for the two handle readers (`FlatNode`, `LazyNode`); it does not apply to `Node`, a self-contained value with no document anchor.
 
 > **Experimental** — new in v0.4.2: API details may still change in a 0.4.x release while ecosystem usage settles. Feedback welcome on the [issue tracker](https://github.com/JuliaData/XML.jl/issues).
 

--- a/src/XML.jl
+++ b/src/XML.jl
@@ -6,7 +6,7 @@ export
     nodetype, tag, attributes, value, children, children!, eachchildnode, eachattribute,
     eachelement, elements,
     foreach_attr,
-    is_simple, simple_value, is_simple_value, sourcetext, sourcespan,
+    is_simple, simple_value, is_simple_value, sourcetext, sourcespan, splicetext,
     depth, siblings, issamenode,
     Cursor, next!, for_each_child, @for_each_child, skip_element!, eof,
     xpath,

--- a/src/XML.jl
+++ b/src/XML.jl
@@ -6,7 +6,7 @@ export
     nodetype, tag, attributes, value, children, children!, eachchildnode, eachattribute,
     eachelement, elements,
     foreach_attr,
-    is_simple, simple_value, is_simple_value, sourcetext,
+    is_simple, simple_value, is_simple_value, sourcetext, sourcespan,
     depth, siblings, issamenode,
     Cursor, next!, for_each_child, @for_each_child, skip_element!, eof,
     xpath,

--- a/src/flatnode.jl
+++ b/src/flatnode.jl
@@ -340,6 +340,15 @@ function sourcespan(n::FlatNode)
 end
 
 """
+    splicetext(n::FlatNode, replacement::AbstractString = "") -> String
+
+Same contract as the `LazyNode` method; the node's span is answered in O(1) from the
+store.
+"""
+splicetext(n::FlatNode, replacement::AbstractString = "") =
+    _splice_span(n.store.source, sourcespan(n), replacement)
+
+"""
     parent(n::FlatNode) -> FlatNode or nothing
 
 O(1) parent lookup (the flat store keeps parent links). Returns `nothing` for the

--- a/src/flatnode.jl
+++ b/src/flatnode.jl
@@ -327,6 +327,19 @@ function sourcetext(n::FlatNode)
 end
 
 """
+    sourcespan(n::FlatNode) -> UnitRange{Int}
+
+O(1): answered straight from the store's per-record source spans. Same contract and
+splice idiom as the `LazyNode` method — valid character indices, with
+`sourcetext(n) == SubString(source, sourcespan(n))`.
+"""
+function sourcespan(n::FlatNode)
+    so, se = @inbounds n.store.spans[n.i]
+    so == se && return (Int(so) + 1):Int(so)
+    (Int(so) + 1):prevind(n.store.source, Int(se) + 1)
+end
+
+"""
     parent(n::FlatNode) -> FlatNode or nothing
 
 O(1) parent lookup (the flat store keeps parent links). Returns `nothing` for the

--- a/src/lazynode.jl
+++ b/src/lazynode.jl
@@ -379,6 +379,31 @@ function sourcetext(n::LazyNode)
     end
 end
 
+"""
+    sourcespan(n::LazyNode) -> UnitRange{Int}
+
+The range of *valid character indices* of the node's original source text within the
+retained source string, so that `source[sourcespan(n)] == sourcetext(n)` — the positional
+counterpart of [`sourcetext`](@ref), for consumers that need *where* the node lives rather
+than its text (verbatim excision and splicing, error context).
+
+The bounds are character indices, not code units: the library performs the `prevind`
+computation, so a node ending on a multi-byte character yields indices that are safe to
+slice with. To splice text *around* a node, step over its boundaries with
+`prevind`/`nextind`:
+
+    s[1:prevind(s, first(span))] * replacement * s[nextind(s, last(span)):end]
+
+Defined for the two source-retaining readers (`LazyNode`, `FlatNode`); like `sourcetext`,
+it does not apply to `Node`, which retains no source.
+"""
+function sourcespan(n::LazyNode)
+    ss = sourcetext(n)
+    o = ss.offset
+    isempty(ss) && return (o + 1):o
+    (o + 1):prevind(ss.string, o + ncodeunits(ss) + 1)
+end
+
 #-----------------------------------------------------------------------------# write
 """
     write(n::LazyNode; normalize::Bool=false, indentsize::Int=2) -> String

--- a/src/lazynode.jl
+++ b/src/lazynode.jl
@@ -394,6 +394,8 @@ slice with. To splice text *around* a node, step over its boundaries with
 
     s[1:prevind(s, first(span))] * replacement * s[nextind(s, last(span)):end]
 
+The packaged form of that splice is [`splicetext`](@ref).
+
 Defined for the two source-retaining readers (`LazyNode`, `FlatNode`); like `sourcetext`,
 it does not apply to `Node`, which retains no source.
 """
@@ -403,6 +405,24 @@ function sourcespan(n::LazyNode)
     isempty(ss) && return (o + 1):o
     (o + 1):prevind(ss.string, o + ncodeunits(ss) + 1)
 end
+
+# the multi-byte-safe splice around a character-index span (shared by the two handle readers)
+_splice_span(src::AbstractString, span::UnitRange{Int}, replacement::AbstractString) =
+    string(SubString(src, firstindex(src), prevind(src, first(span))), replacement,
+           SubString(src, nextind(src, last(span))))
+
+"""
+    splicetext(n, replacement::AbstractString = "") -> String
+
+The node's document source with the node's own text replaced by `replacement` — excised
+entirely by default. This is the packaged, multi-byte-safe form of splicing around
+[`sourcespan`](@ref): `Base.splice!`'s remove-and-insert, applied to the retained source
+and returning a new `String` (nothing is mutated).
+
+Defined for the two source-retaining readers (`LazyNode`, `FlatNode`).
+"""
+splicetext(n::LazyNode, replacement::AbstractString = "") =
+    _splice_span(n.data, sourcespan(n), replacement)
 
 #-----------------------------------------------------------------------------# write
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3692,6 +3692,8 @@ end
             span = sourcespan(a)
             stripped = xml[1:prevind(xml, first(span))] * "<c/>" * xml[nextind(xml, last(span)):end]
             @test stripped == "<r>é<c/>œ<b/><!-- ç --></r>"
+            @test splicetext(a, "<c/>") == stripped              # the packaged form
+            @test splicetext(a) == "<r>éœ<b/><!-- ç --></r>"     # default = pure excision
         end
 
         @testset "text node ending on a multibyte character" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3665,6 +3665,42 @@ end
         end
     end
 
+    @testset "sourcespan" begin
+        # sourcetext(n) == SubString(source, sourcespan(n)) on every node — valid
+        # character indices, multibyte at both boundaries.
+        xml = "<r>é<a x=\"1\">héé</a>œ<b/><!-- ç --></r>"
+        doc = parse(xml, LazyNode)
+        function check_spans(n)
+            span = sourcespan(n)
+            @test span isa UnitRange{Int}
+            @test SubString(xml, span) == sourcetext(n)
+            @test xml[span] == sourcetext(n)
+            for c in XML.eachchildnode(n)
+                check_spans(c)
+            end
+        end
+        check_spans(doc)
+
+        @testset "document spans the whole source" begin
+            @test sourcespan(doc) == firstindex(xml):lastindex(xml)
+        end
+
+        @testset "splice idiom from the docstring" begin
+            # excise <a …>…</a> — preceded by "é", followed by "œ": the documented
+            # prevind/nextind splice must survive both multibyte boundaries
+            a = first(c for c in children(doc[1]) if nodetype(c) == Element)
+            span = sourcespan(a)
+            stripped = xml[1:prevind(xml, first(span))] * "<c/>" * xml[nextind(xml, last(span)):end]
+            @test stripped == "<r>é<c/>œ<b/><!-- ç --></r>"
+        end
+
+        @testset "text node ending on a multibyte character" begin
+            s = "<x>héé</x>"
+            txt = first(c for c in children(parse(s, LazyNode)[1]) if nodetype(c) == Text)
+            @test s[sourcespan(txt)] == "héé"
+        end
+    end
+
     @testset "write(::LazyNode)" begin
         @testset "write returns String" begin
             xml = "<root><child>text</child></root>"

--- a/test/test_flatnode.jl
+++ b/test/test_flatnode.jl
@@ -178,6 +178,18 @@ end
     stripped = xml[1:prevind(xml, first(sp))] * "<c/>" * xml[nextind(xml, last(sp)):end]
     @test occursin("é<c/>œ", stripped)
     @test parse(stripped, FlatNode) isa FlatNode
+
+    # splicetext packages that idiom: node by node it matches the hand-rolled form,
+    # including the first child (span starts at index 1) and the root (span ends at end)
+    @test splicetext(it, "<c/>") == stripped
+    for n in children(f)
+        spn = sourcespan(n)
+        expected = xml[1:prevind(xml, first(spn))] * "@" * xml[nextind(xml, last(spn)):end]
+        @test splicetext(n, "@") == expected
+    end
+    @test splicetext(it) == xml[1:prevind(xml, first(sp))] * xml[nextind(xml, last(sp)):end]
+    lzit = first(c for c in children(first(c for c in children(lz) if nodetype(c) === XML.Element)) if nodetype(c) === XML.Element)
+    @test splicetext(lzit, "<c/>") == stripped                   # cross-reader parity
 end
 
 @testset "BOM handling" begin

--- a/test/test_flatnode.jl
+++ b/test/test_flatnode.jl
@@ -146,6 +146,40 @@ end
     @test Node(only(eachelement(parse(String(sourcetext(it)), FlatNode; wellformed = :lenient)))) == Node(it)
 end
 
+@testset "sourcespan (character-index spans)" begin
+    # Multibyte characters sit at both boundaries of the interesting spans: the <item>
+    # element is preceded by a text node ending in "é" and followed by one starting with "œ".
+    xml = """<?xml version="1.0"?><!DOCTYPE r><!-- ç --><r a="é">é<item>héé</item>œ<empty/><![CDATA[cd]]><?pi tgt?></r>"""
+    f  = parse(xml, FlatNode)
+    lz = parse(xml, LazyNode)
+
+    # invariant + cross-reader parity, on every node of the tree
+    function walk_pairs(a, b)
+        sa, sb = sourcespan(a), sourcespan(b)
+        @test sa isa UnitRange{Int}
+        @test sa == sb
+        @test SubString(xml, sa) == sourcetext(a)
+        @test xml[sa] == sourcetext(a)
+        @test length(children(a)) == length(children(b))
+        for (ca, cb) in zip(children(a), children(b))
+            walk_pairs(ca, cb)
+        end
+    end
+    walk_pairs(f, lz)
+
+    @test sourcespan(f) == firstindex(xml):lastindex(xml)        # Document = whole source
+
+    # O(1) path answers straight from the stored spans
+    it = first(eachelement(only(eachelement(f))))
+    @test xml[sourcespan(it)] == "<item>héé</item>"
+
+    # the documented splice idiom, with multibyte on both sides of the excised span
+    sp = sourcespan(it)
+    stripped = xml[1:prevind(xml, first(sp))] * "<c/>" * xml[nextind(xml, last(sp)):end]
+    @test occursin("é<c/>œ", stripped)
+    @test parse(stripped, FlatNode) isa FlatNode
+end
+
 @testset "BOM handling" begin
     bom = "﻿<r>x</r>"
     @test parse(bom, FlatNode) == parse(bom, Node)


### PR DESCRIPTION
Closes #92.

`sourcespan(n) -> UnitRange{Int}` on `LazyNode` and `FlatNode`: the range of *valid character indices* the node's original source text occupies, with the invariant `sourcetext(n) == SubString(source, sourcespan(n))`. The library does the `prevind` computation, so multi-byte boundaries are safe to slice with; the `sourcespan(::LazyNode)` docstring documents the safe way to splice text around a node: `s[1:prevind(s, first(span))] * replacement * s[nextind(s, last(span)):end]`.

`splicetext(n, replacement = "") -> String` packages that idiom: the document source with the node's own text replaced — excised entirely by default, nothing mutated. `Base.splice!`'s remove-and-insert, for the retained source string.

At the motivating call site (XLSX.jl v0.12's `splitNode`, reached from four places across read/stream/write), the position-and-splice half — five lines reading `token.offset` and a second cursor's `st.state.pos`, plus the byte-arithmetic splice — collapses to `splicetext(target_lazy, replacement)`: one public, tested contract instead of two private conventions that a patch release could silently move.

Implementation: the `LazyNode` methods derive from `sourcetext`'s `SubString` (same forward scan, so the invariant holds by construction); the `FlatNode` methods answer in O(1) from the stored per-record spans, using `_fsub`'s own `prevind` formula; one shared `_splice_span` helper carries the boundary arithmetic.

Tests (RED first, each half): the invariant swept over every node of a document carrying multi-byte characters at both boundaries of the interesting spans; cross-reader span parity (`FlatNode` == `LazyNode`); the Document node spanning the whole source; and `splicetext` checked node-by-node against the hand-rolled idiom, covering a span starting at the first index and one ending at the last. Full suite: 3526/3526.

Docs: the README's `LazyNode` extras list and `FlatNode` section gain the three-accessor family alongside `sourcetext`; CHANGELOG entries under Unreleased.