### PR TITLE
Attribute-value normalization per XML 1.0 §3.3.3 (read + write)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the node's own text replaced — excised entirely by default. The packaged, multi-byte-safe
   form of the `sourcespan` splice (#92).
 
+### Fixed
+
+- **Attribute values are now normalized per XML 1.0 §3.3.3** (all four readers): literal
+  tab/newline/CR in an attribute value read as spaces — the CR LF pair as a single space —
+  while white space written as character references (`&#9;` `&#10;` `&#13;`) still reads
+  as the referenced character. Previously the raw characters came through, so a document
+  with attributes wrapped across lines read differently in XML.jl than in conforming
+  parsers such as libxml2. On write, attribute values now escape literal tab/newline/CR as
+  character references, so values round-trip exactly (#93).
+
 - **`parse(str, Cursor)`, `read(filename, Cursor)`, `read(io, Cursor)`** — `Cursor` gains the
   tree readers' entry points: same argument order, and the `read` forms apply the same
   byte-level BOM normalization (UTF-8 BOM strip, UTF-16 LE/BE transcoding; a BOM-less UTF-16

--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -178,8 +178,10 @@ function value(c::Cursor)
     nothing
 end
 
-@inline _cursor_decode_attr(tok, data) =
-    tok.has_entities ? unescape(attr_value(tok, data)) : attr_value(tok, data)
+@inline function _cursor_decode_attr(tok, data)
+    v = _normalize_attr_ws(attr_value(tok, data))
+    tok.has_entities ? unescape(v) : v
+end
 @inline _cursor_as_substring(s::SubString{String}) = s
 @inline _cursor_as_substring(s::String) = SubString(s, 1, lastindex(s))
 

--- a/src/escape.jl
+++ b/src/escape.jl
@@ -55,6 +55,40 @@ function unescape(x::AbstractString)
     replace(s, _ENTITY_RE => _unescape_entity)
 end
 
+# XML 1.0 §3.3.3 attribute-value normalization, applied to the RAW value slice BEFORE
+# entity resolution: the literal pair CR LF becomes ONE space, then each remaining literal
+# #x9 / #xA / #xD becomes a space. Character references (`&#10;` …) are untouched here and
+# resolve afterwards — which is exactly why this pass must run before `unescape`. All the
+# targets are ASCII, so the byte loop is multi-byte-safe. Clean values return unchanged
+# (no allocation) — the dominant case.
+function _normalize_attr_ws(s::AbstractString)
+    cu = codeunits(s)
+    dirty = false
+    @inbounds for b in cu
+        if b == 0x09 || b == 0x0A || b == 0x0D
+            dirty = true
+            break
+        end
+    end
+    dirty || return s
+    io = IOBuffer(sizehint = ncodeunits(s))
+    n = length(cu)
+    j = 1
+    @inbounds while j <= n
+        b = cu[j]
+        if b == 0x0D
+            Base.write(io, 0x20)
+            j < n && cu[j + 1] == 0x0A && (j += 1)
+        elseif b == 0x0A || b == 0x09
+            Base.write(io, 0x20)
+        else
+            Base.write(io, b)
+        end
+        j += 1
+    end
+    String(take!(io))
+end
+
 function unescape(x::SubString{String})
     occursin('&', x) || return x
     replace(String(x), _ENTITY_RE => _unescape_entity)

--- a/src/flatnode.jl
+++ b/src/flatnode.jl
@@ -306,8 +306,8 @@ function attributes(n::FlatNode)
     for _ in 1:r.attr_count
         a = @inbounds n.store.attrs[ai]
         name = _fsub(n.store, a.name_offset, a.name_len)
-        rawv = _fsub(n.store, a.value_offset, abs(a.value_len))
-        val = a.value_len < 0 ? _as_substring(unescape(rawv)) : rawv
+        rawv = _normalize_attr_ws(_fsub(n.store, a.value_offset, abs(a.value_len)))
+        val = _as_substring(a.value_len < 0 ? unescape(rawv) : rawv)
         push!(out, name => val)
         ai += Int32(1)
     end

--- a/src/lazynode.jl
+++ b/src/lazynode.jl
@@ -50,7 +50,10 @@ _lazy_tokenizer(n::LazyNode) = tokenize(n.data, _lazy_pos(n))
 # and no byte scan — the dominant case for spreadsheet-style data. `_decode_attr` strips
 # the surrounding quotes first; the flag is read from the token, not the stripped view.
 @inline _decode(tok::Token, data) = tok.has_entities ? unescape(raw(tok, data)) : raw(tok, data)
-@inline _decode_attr(tok::Token, data) = tok.has_entities ? unescape(attr_value(tok, data)) : attr_value(tok, data)
+@inline function _decode_attr(tok::Token, data)
+    v = _normalize_attr_ws(attr_value(tok, data))
+    tok.has_entities ? unescape(v) : v
+end
 
 #-----------------------------------------------------------------------------# tag / value
 function tag(n::LazyNode)

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -189,7 +189,7 @@ function _parse(xml::String, ::Type{S}, convert_text::F, ::Val{W}) where {S, F, 
             W !== :lenient && occursin('<', rawval) && error("not well-formed: '<' in attribute value (XML 1.0 §3.1)")
             W === :strict && _check_chars_strict(rawval)
             W === :strict && token.has_entities && _check_charrefs_strict(rawval)
-            val = _text_value(S, rawval, token.has_entities, convert_text)
+            val = _text_value(S, _normalize_attr_ws(rawval), token.has_entities, convert_text)
             name = _to(S, pending_attr_name)
             if decl_attrs !== nothing
                 any(p -> first(p) == name, decl_attrs) && error("Duplicate attribute: $name")

--- a/src/write.jl
+++ b/src/write.jl
@@ -33,6 +33,36 @@ const _INDENT_STRINGS = [" " ^ n for n in 0:_MAX_CACHED_INDENT]
     " " ^ n
 end
 
+# Attribute values additionally escape literal #x9/#xA/#xD as character references: a
+# conforming reader normalizes literal white space in attribute values to spaces
+# (XML 1.0 §3.3.3), so only the reference form survives a round-trip.
+function _write_attr_escaped(io::IO, s::String)
+    start = 1
+    i = 1
+    n = ncodeunits(s)
+    @inbounds while i <= n
+        b = codeunit(s, i)
+        esc = if b == UInt8('&'); "&amp;"
+        elseif b == UInt8('<'); "&lt;"
+        elseif b == UInt8('>'); "&gt;"
+        elseif b == UInt8('"'); "&quot;"
+        elseif b == UInt8('\''); "&apos;"
+        elseif b == UInt8('\t'); "&#9;"
+        elseif b == UInt8('\n'); "&#10;"
+        elseif b == UInt8('\r'); "&#13;"
+        else
+            i += 1
+            continue
+        end
+        i > start && GC.@preserve s Base.unsafe_write(io, pointer(s, start), (i - start) % UInt)
+        print(io, esc)
+        i += 1
+        start = i
+    end
+    start <= n && GC.@preserve s Base.unsafe_write(io, pointer(s, start), (n - start + 1) % UInt)
+    nothing
+end
+
 # Serialize `key="escaped-value"` pairs for an attributes vector (no leading space outside).
 # Uses byte-level `Base.write` instead of `print` to avoid the varargs-print dispatch
 # overhead that shows up under profile when an element has many attributes.
@@ -43,7 +73,7 @@ function _print_attrs(io::IO, attributes)
         Base.write(io, k)
         Base.write(io, UInt8('='))
         Base.write(io, UInt8('"'))
-        _write_escaped(io, v)
+        _write_attr_escaped(io, v)
         Base.write(io, UInt8('"'))
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3182,6 +3182,70 @@ end
         @test doc[1]["a"] == "a&b"
     end
 
+    @testset "attribute-value normalization (XML 1.0 §3.3.3)" begin
+        # Literal white space (#x9 #xA #xD) in attribute values reads as spaces — the CRLF
+        # pair as ONE space — while white space written as character references survives.
+        # Normalization happens on the raw slice, before entity resolution, uniformly
+        # across the four readers.
+        function attr_by_reader(xml, name)
+            n = only(elements(parse(xml, Node)))[name]
+            l = only(elements(parse(xml, LazyNode)))[name]
+            f = only(elements(parse(xml, FlatNode)))[name]
+            cur = Cursor(xml)
+            c = nothing
+            while next!(cur) !== nothing
+                nodetype(cur) === Element && (c = attributes(cur)[name])
+            end
+            (n, l, f, c)
+        end
+
+        @testset "literal whitespace becomes spaces" begin
+            vals = attr_by_reader("<a note=\"L1\nL2\tT\rR\"/>", "note")
+            @test all(==("L1 L2 T R"), vals)
+        end
+
+        @testset "character references survive" begin
+            vals = attr_by_reader("<a note=\"L1&#10;L2&#9;T&#13;R\"/>", "note")
+            @test all(==("L1\nL2\tT\rR"), vals)
+        end
+
+        @testset "the CRLF pair collapses to one space" begin
+            vals = attr_by_reader("<a note=\"L1\r\nL2\"/>", "note")
+            @test all(==("L1 L2"), vals)
+            @test only(elements(parse("<a n=\"x\r\n\r\ny\"/>", Node)))["n"] == "x  y"
+            @test only(elements(parse("<a n=\"x\n\r\ny\"/>", Node)))["n"] == "x  y"
+        end
+
+        @testset "single-attribute fast paths" begin
+            lz = only(elements(parse("<a note=\"p\tq\"/>", LazyNode)))
+            @test get(lz, "note", "") == "p q"
+            cur = Cursor("<a note=\"p\tq\"/>")
+            while next!(cur) !== nothing
+                nodetype(cur) === Element && @test get(cur, "note", "") == "p q"
+            end
+        end
+
+        @testset "eachattribute path" begin
+            el = only(elements(parse("<a x=\"1\n2\" y=\"&#10;\"/>", LazyNode)))
+            @test collect(XML.eachattribute(el)) == ["x" => "1 2", "y" => "\n"]
+        end
+
+        @testset "W3C xmltest 043: attribute wrapped across a CRLF line" begin
+            # byte-for-byte the suite's xmltest/valid/sa/043.xml (CRLF line ends); its
+            # canonical reference out/043.xml expects a1="foo bar" — one space
+            xml043 = "<!DOCTYPE doc [\r\n<!ATTLIST doc a1 CDATA #IMPLIED>\r\n<!ELEMENT doc (#PCDATA)>\r\n]>\r\n<doc a1=\"foo\r\nbar\"></doc>\r\n"
+            @test only(elements(parse(xml043, Node)))["a1"] == "foo bar"
+        end
+
+        @testset "write escapes attribute whitespace as character references" begin
+            el = XML.Element("a"; note = "L1\nL2\tT\rR")
+            out = XML.write(el)
+            @test occursin("note=\"L1&#10;L2&#9;T&#13;R\"", out)
+            back = only(elements(parse(out, Node)))
+            @test back["note"] == "L1\nL2\tT\rR"         # the value round-trips exactly
+        end
+    end
+
     @testset "Declaration attributes" begin
         doc = parse("""<?xml version="1.0" encoding="UTF-8"?><root/>""", LazyNode)
         decl = doc[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3187,14 +3187,15 @@ end
         # pair as ONE space — while white space written as character references survives.
         # Normalization happens on the raw slice, before entity resolution, uniformly
         # across the four readers.
+        getattr(x, name) = Dict(attributes(x))[name]
         function attr_by_reader(xml, name)
-            n = only(elements(parse(xml, Node)))[name]
-            l = only(elements(parse(xml, LazyNode)))[name]
-            f = only(elements(parse(xml, FlatNode)))[name]
+            n = getattr(only(elements(parse(xml, Node))), name)
+            l = getattr(only(elements(parse(xml, LazyNode))), name)
+            f = getattr(only(elements(parse(xml, FlatNode))), name)
             cur = Cursor(xml)
             c = nothing
             while next!(cur) !== nothing
-                nodetype(cur) === Element && (c = attributes(cur)[name])
+                nodetype(cur) === Element && (c = getattr(cur, name))
             end
             (n, l, f, c)
         end

--- a/test/test_libxml2_testcases.jl
+++ b/test/test_libxml2_testcases.jl
@@ -269,11 +269,12 @@ end
 #==============================================================================#
 @testset "Attributes" begin
     @testset "att1: attribute with newlines (whitespace normalization)" begin
-        # libxml2 test/att1
+        # libxml2 test/att1 — upstream's result/att1 expects the literal newline
+        # normalized to a space and the four-space run kept (XML 1.0 §3.3.3, CDATA rule)
         xml = "<doc attr=\"to normalize\nwith a    space\"/>"
         doc = parse(xml, Node)
         @test tag(doc[1]) == "doc"
-        @test haskey(doc[1], "attr")
+        @test doc[1]["attr"] == "to normalize with a    space"
     end
 
     @testset "att2: attribute with multiple spaces" begin
@@ -284,11 +285,12 @@ end
     end
 
     @testset "att3: attribute with character references" begin
-        # libxml2 test/att3
+        # libxml2 test/att3 — the referenced newline (&#10;) survives as a newline while
+        # the literal spaces stay spaces: the discriminating case of §3.3.3
         xml = """<select onclick="aaaa&#10;      bbbb&#160;">f&#160;oo</select>"""
         doc = parse(xml, Node)
         @test tag(doc[1]) == "select"
-        @test haskey(doc[1], "onclick")
+        @test doc[1]["onclick"] == "aaaa\n      bbbb\ua0"
     end
 
     @testset "att4: complex document with many attributes" begin


### PR DESCRIPTION
Closes #93.

Reading: `_normalize_attr_ws` runs on the raw value slice *before* entity resolution, in the decode funnels of all four readers: the literal CR LF pair becomes ONE space (line ends normalize before §3.3.3 applies), each remaining literal #x9/#xA/#xD becomes a space, and character references survive untouched — they resolve afterwards, which is the point of the ordering. Clean values return unchanged (no allocation, the dominant case). No trimming and no run-collapsing: with no DTD attribute types, every attribute is CDATA.

Writing: attribute values now escape literal #x9/#xA/#xD as character references (`&#9;` `&#10;` `&#13;`), as libxml2 emits. Required for round-trips once the reader normalizes: fixing the read side alone would make XML.jl read back its own output with spaces where the application had put newlines.

Design note: the issue sketched a `has_ws` token flag; detection happens at decode time instead — the tokenizer never byte-scans attribute values (memchr to the closing quote plus a bounded `&` check), so a flag would add a scan per tokenized value even when it is never decoded, against `LazyNode`'s pay-per-touch — and `FlatNode`'s attribute record has only the one sign channel (`value_len < 0` = has-entities).

Tests (RED first): a four-reader matrix — literal whitespace reads as spaces, the CRLF pair as one space, character references survive (pre-existing behavior, kept as a guard); the single-attribute fast paths (`get` on `LazyNode` and `Cursor`) and `eachattribute`; the W3C xmltest `043` case inline byte-for-byte (its canonical reference expects `a1="foo bar"`); and the write half, with the exact round-trip of the value. libxml2 `att1`/`att3` strengthened from `haskey` to upstream's expected values. Full suite: 3537/3537, W3C `FlatNode` ≡ `Node` parity intact.

CHANGELOG under Unreleased/Fixed — this changes observed values for documents with attributes wrapped across lines: they now read as in conforming parsers.