### PR TITLE
`LazyNode`: defer the child-subtree skip to the next sibling request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the node's own text replaced — excised entirely by default. The packaged, multi-byte-safe
   form of the `sourcespan` splice (#92).
 
+### Changed
+
+- **`LazyNode`'s child iterator defers each yielded element's subtree skip** until the
+  next sibling is requested: a traversal that stops early only tokenizes the bytes it
+  actually stepped over, making descents O(bytes before the target) — touching a 14 MB
+  document's root element drops from ~35 ms to ~4 µs, a nine-node document-order descent
+  from ~50 ms to ~5 µs. Full traversals do the same total work as before (#91).
+
 ### Fixed
 
 - **Attribute values are now normalized per XML 1.0 §3.3.3** (all four readers): literal

--- a/PERFORMANCE-v0.4.md
+++ b/PERFORMANCE-v0.4.md
@@ -51,7 +51,18 @@ Structured pull helpers keep scans cheap without hand-tracked depth: `for_each_c
 
 Opening is a no-op wrapper (~0.5 µs on this 14 MB file) and nothing is ever cached: each visit re-tokenizes and rebuilds its small handles (~1 KB allocated per repeated look-up), so costs repeat per visit. A traversal pays only for the bytes it actually steps over: the child iterator defers a yielded element's subtree skip until the *next sibling* is requested, so descending to a target is O(bytes before it) — touching this document's root element costs ~4 µs, and a nine-node document-order descent ~5 µs. What still costs: *horizontal* scans pay the subtrees they step past (as any index-free forward reader must), and *repeated* look-ups pay again — those two patterns tip the scale toward `FlatNode`/`Node`.
 
-One consumer note: ask only for what you need — a `for` loop over `eachchildnode` fetches the next sibling (and pays its predecessor's deferred subtree skip) at the top of each round, so `break` before that fetch once you are done.
+> [!NOTE]
+> Ask only for what you need: a `for` loop over `eachchildnode` fetches the next sibling — and pays its predecessor's deferred subtree skip — at the top of each round, so exit *from within the body* once you are done:
+>
+> ```julia
+> out = LazyNode[]                  # goal: keep the first three children
+> for c in eachchildnode(parent)
+>     push!(out, c)
+>     length(out) == 3 && break     # decided in the body — no fourth fetch
+> end
+> ```
+>
+> Move that test to the top of the body instead — `length(out) == 3 && break; push!(out, c)` — and the loop only learns it is done at round *four*, whose fetch has already paid the third child's deferred subtree skip.
 
 ### Full DOM — parse + walk everything
 

--- a/PERFORMANCE-v0.4.md
+++ b/PERFORMANCE-v0.4.md
@@ -49,10 +49,9 @@ Structured pull helpers keep scans cheap without hand-tracked depth: `for_each_c
 
 ### Partial reads — `LazyNode`
 
-Opening is a no-op wrapper (~0.5 µs on this 14 MB file) and nothing is ever cached: each visit re-tokenizes and rebuilds its small handles (~1 KB allocated per repeated look-up), so costs repeat per visit. Partial reads are cheap when the *touched* nodes have small spans — leaf-ward hops, flat or kilobyte-scale documents (typical web-service responses parse in well under a millisecond) — and *repeated* look-ups tip the scale toward `FlatNode`/`Node`.
+Opening is a no-op wrapper (~0.5 µs on this 14 MB file) and nothing is ever cached: each visit re-tokenizes and rebuilds its small handles (~1 KB allocated per repeated look-up), so costs repeat per visit. A traversal pays only for the bytes it actually steps over: the child iterator defers a yielded element's subtree skip until the *next sibling* is requested, so descending to a target is O(bytes before it) — touching this document's root element costs ~4 µs, and a nine-node document-order descent ~5 µs. What still costs: *horizontal* scans pay the subtrees they step past (as any index-free forward reader must), and *repeated* look-ups pay again — those two patterns tip the scale toward `FlatNode`/`Node`.
 
-> [!NOTE]
-> **As of v0.4.2**, yielding a child *pre-skips* (tokenizes) that child's whole subtree to position for its sibling — so merely touching this document's root element costs ~35 ms (its subtree is nearly the whole file), and a 9-node descent to the first `<item>` ~50 ms: on a document dominated by one huge container, a `FlatNode`/`Node` build amortizes almost immediately.
+One consumer note: ask only for what you need — a `for` loop over `eachchildnode` fetches the next sibling (and pays its predecessor's deferred subtree skip) at the top of each round, so `break` before that fetch once you are done.
 
 ### Full DOM — parse + walk everything
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ doc = read("file.xml", LazyNode)
 
 `LazyNode` supports the same read-only interface as `Node`: `nodetype`, `tag`, `attributes`, `value`, `children`, `is_simple`, `simple_value`, plus integer and string indexing.
 
-`LazyNode` is for *partial* reads only: opening is a no-op wrapper (~0.5 µs whatever the file size) and you pay per node *touched* — a touch spans the node's subtree, and nothing is cached, so repeated visits pay the full price again. Unbeatable for leaf-ward hops and kilobyte-scale documents; for whole-tree walks (276 ms vs ~55/~106 ms build+walk on the 14 MB corpus below), repeated queries, or plucking one child out of a huge container, build `FlatNode` or `Node` instead — see [Performance by access pattern](#performance-by-access-pattern).
+`LazyNode` is for *partial* reads only: opening is a no-op wrapper (~0.5 µs whatever the file size), a traversal pays only for the bytes it steps over — descending to a target is O(bytes before it), so reaching this 14 MB file's root element costs ~4 µs — and nothing is cached, so repeated visits pay again. Unbeatable for descents and kilobyte-scale documents; for whole-tree walks (276 ms vs ~55/~106 ms build+walk on the 14 MB corpus below) and repeated queries, build `FlatNode` or `Node` instead — see [Performance by access pattern](#performance-by-access-pattern).
 
 For streaming and high-throughput workloads, several extra accessors avoid materializing intermediate collections:
 

--- a/benchmarks/benchmarks_results.md
+++ b/benchmarks/benchmarks_results.md
@@ -2,84 +2,84 @@
 
 ```
 Parse (small)
-	XML.jl             0.0218 ms
-	XML.jl (SS)        0.0195 ms
-	EzXML              0.0133 ms  (XML.jl 64.3% slower)
-	LightXML           0.0114 ms  (XML.jl 91.2% slower)
-	XMLDict              0.11 ms  (XML.jl 80.1% faster)
+	XML.jl             0.0216 ms
+	XML.jl (SS)        0.0196 ms
+	EzXML              0.0136 ms  (XML.jl 58.9% slower)
+	LightXML           0.0112 ms  (XML.jl 91.8% slower)
+	XMLDict             0.112 ms  (XML.jl 80.7% faster)
 
 Parse (medium)
-	XML.jl              110.0 ms
-	XML.jl (SS)         127.0 ms
-	EzXML                46.8 ms  (XML.jl 134.7% slower)
-	LightXML             47.1 ms  (XML.jl 133.3% slower)
-	XMLDict             348.0 ms  (XML.jl 68.4% faster)
+	XML.jl              115.0 ms
+	XML.jl (SS)         107.0 ms
+	EzXML                47.2 ms  (XML.jl 143.3% slower)
+	LightXML             47.5 ms  (XML.jl 141.8% slower)
+	XMLDict             352.0 ms  (XML.jl 67.3% faster)
 
 Write (small)
-	XML.jl             0.0056 ms
-	EzXML             0.00588 ms  (~same)
-	LightXML           0.0592 ms  (XML.jl 90.5% faster)
+	XML.jl            0.00572 ms
+	EzXML             0.00574 ms  (~same)
+	LightXML           0.0573 ms  (XML.jl 90.0% faster)
 
 Write (medium)
-	XML.jl               27.7 ms
-	EzXML                21.1 ms  (XML.jl 31.2% slower)
-	LightXML             29.1 ms  (~same)
+	XML.jl               28.3 ms
+	EzXML                21.1 ms  (XML.jl 34.3% slower)
+	LightXML             30.3 ms  (XML.jl 6.5% faster)
 
 Read file
-	XML.jl              102.0 ms
-	EzXML                59.5 ms  (XML.jl 71.8% slower)
-	LightXML             84.9 ms  (XML.jl 20.3% slower)
+	XML.jl              110.0 ms
+	EzXML                60.0 ms  (XML.jl 83.6% slower)
+	LightXML             70.2 ms  (XML.jl 56.9% slower)
 
 Collect tags (small)
 	XML.jl           0.000371 ms
-	EzXML             0.00111 ms  (XML.jl 66.4% faster)
-	LightXML          0.00183 ms  (XML.jl 79.7% faster)
+	EzXML             0.00109 ms  (XML.jl 65.8% faster)
+	LightXML           0.0018 ms  (XML.jl 79.4% faster)
 
 Collect tags (medium)
 	XML.jl               5.63 ms
-	EzXML                10.4 ms  (XML.jl 45.7% faster)
-	LightXML             12.9 ms  (XML.jl 56.2% faster)
+	EzXML                10.6 ms  (XML.jl 46.7% faster)
+	LightXML             12.7 ms  (XML.jl 55.5% faster)
 
 Parse SST (LazyNode)
 	XML.jl            4.96e-6 ms
-	Node (for ref)       16.9 ms  (XML.jl 100.0% faster)
+	Node (for ref)       17.1 ms  (XML.jl 100.0% faster)
 
 Parse worksheet (LazyNode)
 	XML.jl            4.96e-6 ms
-	Node (for ref)       27.8 ms  (XML.jl 100.0% faster)
+	Node (for ref)       28.5 ms  (XML.jl 100.0% faster)
 
 SST: write each <si>
-	LazyNode + write (zero-copy)     33.8 ms
-	LazyNode + write (normalize)     70.7 ms
-	Node (for ref)       5.46 ms
+	LazyNode + write (zero-copy)     33.6 ms
+	LazyNode + write (normalize)     71.7 ms
+	Node (for ref)       5.58 ms
 
 SST: unformatted text
-	LazyNode + is_simple_value     39.1 ms
+	LazyNode + is_simple_value     39.3 ms
 	Node (for ref)       2.39 ms
 
 Worksheet: collect rows
-	children() (fresh Vector each call)     36.2 ms
-	children!(buf, n) (reused buffer)     36.3 ms
+	children() (fresh Vector each call)     36.6 ms
+	children!(buf, n) (reused buffer)     36.4 ms
 
 Worksheet: attribute scan
 	eachattribute        36.3 ms
-	attributes() (materialize dict)     36.3 ms
+	attributes() (materialize dict)     36.5 ms
 
 Worksheet: single attr fetch
-	get(c, "r", "")      36.4 ms
-	attributes(c)["r"]     36.4 ms
+	get(c, "r", "")      36.7 ms
+	attributes(c)["r"]     36.2 ms
 
 Worksheet: <v> value
-	is_simple_value      36.4 ms
-	is_simple + simple_value     36.1 ms
+	is_simple_value      36.6 ms
+	is_simple + simple_value     36.5 ms
 
 XLSX sst_load! (end-to-end)
-	LazyNode             53.4 ms
-	LazyNode (entity-heavy)     47.1 ms
+	LazyNode             53.3 ms
+	LazyNode (entity-heavy)     47.4 ms
 
 XLSX cell read (end-to-end)
-	numeric ws           36.1 ms
-	string ws            33.3 ms
+	numeric ws           36.6 ms
+	string ws            33.6 ms
 
 ```
 

--- a/src/lazynode.jl
+++ b/src/lazynode.jl
@@ -458,10 +458,17 @@ function write(filename::AbstractString, n::LazyNode; normalize::Bool=false, ind
 end
 
 #-----------------------------------------------------------------------------# eachchildnode
+# Iterator state: a yielded element's subtree is NOT skipped at yield time — the skip is
+# recorded as pending and performed only when the next sibling is requested, so a
+# traversal that stops early never pays for subtrees nobody asked to step past.
+const _CI_READY   = 0x00
+const _CI_PENDING = 0x01  # an element was yielded; its unskipped subtree lies ahead
+const _CI_DONE    = 0x02
+
 struct LazyChildIterator{S <: AbstractString, I}
     data::S
     iter::I
-    done::Base.RefValue{Bool}
+    state::Base.RefValue{UInt8}
 end
 
 Base.IteratorSize(::Type{<:LazyChildIterator}) = Base.SizeUnknown()
@@ -479,17 +486,17 @@ function eachchildnode(n::LazyNode{S}) where {S}
     nt = n.nodetype
     iter = _lazy_tokenizer(n)
     if nt === Document
-        return LazyChildIterator{S, typeof(iter)}(n.data, iter, Ref(false))
+        return LazyChildIterator{S, typeof(iter)}(n.data, iter, Ref(_CI_READY))
     elseif nt === Element
         for tok in iter
             if tok.kind === TokenKinds.SELF_CLOSE
-                return LazyChildIterator{S, typeof(iter)}(n.data, iter, Ref(true))
+                return LazyChildIterator{S, typeof(iter)}(n.data, iter, Ref(_CI_DONE))
             elseif tok.kind === TokenKinds.TAG_CLOSE
-                return LazyChildIterator{S, typeof(iter)}(n.data, iter, Ref(false))
+                return LazyChildIterator{S, typeof(iter)}(n.data, iter, Ref(_CI_READY))
             end
         end
     end
-    LazyChildIterator{S, typeof(iter)}(n.data, iter, Ref(true))
+    LazyChildIterator{S, typeof(iter)}(n.data, iter, Ref(_CI_DONE))
 end
 
 # eachelement's generic definition filters children(node); for LazyNode, build on the
@@ -497,15 +504,19 @@ end
 eachelement(node::LazyNode) = Iterators.filter(n -> nodetype(n) === Element, eachchildnode(node))
 
 function Base.iterate(ci::LazyChildIterator, _ = nothing)
-    ci.done[] && return nothing
+    s = ci.state[]
+    s === _CI_DONE && return nothing
+    if s === _CI_PENDING
+        ci.state[] = _CI_READY
+        _lazy_skip_element!(ci.iter)
+    end
     for tok in ci.iter
         k = tok.kind
         if k === TokenKinds.TEXT
             return (LazyNode(ci.data, tok, Text), nothing)
         elseif k === TokenKinds.OPEN_TAG
-            node = LazyNode(ci.data, tok, Element)
-            _lazy_skip_element!(ci.iter)
-            return (node, nothing)
+            ci.state[] = _CI_PENDING
+            return (LazyNode(ci.data, tok, Element), nothing)
         elseif k === TokenKinds.COMMENT_OPEN
             node = LazyNode(ci.data, tok, Comment)
             _lazy_skip_until!(ci.iter, TokenKinds.COMMENT_CLOSE)
@@ -527,11 +538,11 @@ function Base.iterate(ci::LazyChildIterator, _ = nothing)
             _lazy_skip_until!(ci.iter, TokenKinds.DOCTYPE_CLOSE)
             return (node, nothing)
         elseif k === TokenKinds.CLOSE_TAG || k === TokenKinds.TAG_CLOSE
-            ci.done[] = true
+            ci.state[] = _CI_DONE
             return nothing
         end
     end
-    ci.done[] = true
+    ci.state[] = _CI_DONE
     return nothing
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3831,6 +3831,35 @@ end
             @test results == ["<si><t>hello</t></si>", "<si><t>world</t></si>"]
         end
 
+        @testset "sibling positioning semantics" begin
+            # Guards for the iterator's positioning contract: yielded handles are
+            # independent of the parent iterator's stream, resuming after a yielded
+            # element finds its sibling, and abandoned iterators leave no trace.
+            xml = "<r><a><deep><deeper>x</deeper></deep></a>middle<b i=\"1\"/><!-- c --><c/></r>"
+            doc = parse(xml, LazyNode)
+            root = doc[1]
+
+            # full lazy sequence matches the eager collector
+            @test map(nodetype, collect(eachchildnode(root))) == map(nodetype, children(root))
+
+            # interleaved consumption: descend INSIDE a yielded child, then resume the parent
+            it = eachchildnode(root)
+            (a, st) = iterate(it)
+            @test tag(a) == "a"
+            @test simple_value(only(eachelement(only(eachelement(a))))) == "x"
+            (t, st) = iterate(it, st)
+            @test nodetype(t) == Text && value(t) == "middle"
+            (b, st) = iterate(it, st)
+            @test tag(b) == "b" && Dict(attributes(b))["i"] == "1"
+
+            # abandoning an iterator mid-way and starting fresh sees everything again
+            first(eachchildnode(root))
+            @test map(nodetype, collect(eachchildnode(root))) == map(nodetype, children(root))
+
+            # first element via the lazy path equals the eager path
+            @test tag(first(eachelement(root))) == tag(elements(root)[1])
+        end
+
         @testset "non-element/document returns empty" begin
             xml = "<!-- comment --><root/>"
             doc = parse(xml, LazyNode)


### PR DESCRIPTION
Closes #91.

The child iterator's state grows from `done::Bool` to a three-state byte (ready / pending / done): yielding an element records its subtree skip as *pending* instead of running it, and the next `iterate` call performs it first. A traversal that stops early only tokenizes the bytes it actually stepped over; the cheap non-element skips (comment, CData, PI, declaration, DOCTYPE — their skip is their own token) stay eager.

Measured on the 14 MB XMark corpus (median of repeated runs): touching the root element via `first(eachelement(doc))` drops from ~35 ms to **3.7 µs**; the deepest first-element descent (five levels) runs in **4.8 µs**; a nine-node document-order DFS drops from ~50 ms to **5.3 µs**; and the full 882 K-node walk is unchanged — **276.41 ms against 276.46 ms** measured before the change by the same canonical script (`benchmarks/flatnode_bench.jl`), confirming the same-total-work claim to 0.02%. Every other row of that benchmark (`FlatNode`/`Node`/`Cursor` builds and walks) sits within ±2% of its pre-change value, and a full `benchmarks.jl` run shows the LazyNode-heavy XLSX-pattern section invariant within ±3% — those patterns consume children fully, so no total work moves. What the deferral *enables* is the pattern they don't yet exercise: obtaining a worksheet's `<sheetData>` handle and previewing its first rows, which under the eager skip paid the whole sheet's span, now runs in ~34 µs on a 1.3 MiB / 3000-row sheet (vs 7.9 ms to consume it fully). `benchmarks_results.md` is regenerated from the full run.

Tests: sibling-positioning guards committed first and green on the *eager* implementation — the lazy sequence equals the eager collector, descending inside a yielded child then resuming the parent finds the right sibling, abandoned iterators leave no trace, first-element parity between the lazy and eager paths. Full suite: 3544/3544, W3C parity intact.

One consumer note, surfaced by the measurement harness itself and now documented: a `for` loop over `eachchildnode` fetches the next sibling — and pays its predecessor's deferred skip — at the top of each round, so `break` before that fetch once done. The first harness draft paid the old ~50 ms for exactly that mistake.

Docs: the versioned eager-skip note in PERFORMANCE-v0.4.md is removed (it was written to die with this change); the Partial reads sections of PERFORMANCE and the README move to the pay-for-bytes-stepped-over cost model with the new numbers; CHANGELOG under Unreleased/Changed.