### PR TITLE
Type-stable `_normalize_attr_ws`: no box per clean attribute value

### DIFF
--- a/src/escape.jl
+++ b/src/escape.jl
@@ -60,17 +60,22 @@ end
 # #x9 / #xA / #xD becomes a space. Character references (`&#10;` …) are untouched here and
 # resolve afterwards — which is exactly why this pass must run before `unescape`. All the
 # targets are ASCII, so the byte loop is multi-byte-safe. Clean values return unchanged
-# (no allocation) — the dominant case.
-function _normalize_attr_ws(s::AbstractString)
-    cu = codeunits(s)
-    dirty = false
-    @inbounds for b in cu
-        if b == 0x09 || b == 0x0A || b == 0x0D
-            dirty = true
-            break
-        end
+# — the dominant case — and each method returns its input type concretely: a union-typed
+# return would heap-box the clean-path SubString at every call site, one 32-byte box per
+# attribute in every reader's hot path (#98).
+_normalize_attr_ws(s::AbstractString) = _attr_ws_dirty(s) ? _rewrite_attr_ws(s) : s
+_normalize_attr_ws(s::SubString{String}) =
+    _attr_ws_dirty(s) ? SubString(_rewrite_attr_ws(s)) : s
+
+function _attr_ws_dirty(s::AbstractString)
+    @inbounds for b in codeunits(s)
+        (b == 0x09 || b == 0x0A || b == 0x0D) && return true
     end
-    dirty || return s
+    false
+end
+
+function _rewrite_attr_ws(s::AbstractString)
+    cu = codeunits(s)
     io = IOBuffer(sizehint = ncodeunits(s))
     n = length(cu)
     j = 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3255,6 +3255,9 @@ end
             @test only(Base.return_types(XML._normalize_attr_ws, (String,))) === String
             dirty = XML._normalize_attr_ws(SubString("a=\"p\tq\"", 4, 6))
             @test dirty == "p q" && dirty isa SubString{String}
+            # the AbstractString fallback — nothing internal reaches it — keeps the semantics
+            @test XML._normalize_attr_ws("p\tq") == "p q"
+            @test XML._normalize_attr_ws("clean") === "clean"
             measure(v) = @allocated XML._normalize_attr_ws(v)   # function barrier: measure
             measure(clean)                                      # the call, not the caller's
             if Base.JLOptions().code_coverage == 0       # coverage counters skew @allocated

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3255,9 +3255,10 @@ end
             @test only(Base.return_types(XML._normalize_attr_ws, (String,))) === String
             dirty = XML._normalize_attr_ws(SubString("a=\"p\tq\"", 4, 6))
             @test dirty == "p q" && dirty isa SubString{String}
-            XML._normalize_attr_ws(clean)                # warm-up before measuring
+            measure(v) = @allocated XML._normalize_attr_ws(v)   # function barrier: measure
+            measure(clean)                                      # the call, not the caller's
             if Base.JLOptions().code_coverage == 0       # coverage counters skew @allocated
-                @test (@allocated XML._normalize_attr_ws(clean)) == 0
+                @test measure(clean) == 0
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3245,6 +3245,21 @@ end
             back = only(elements(parse(out, Node)))
             @test back["note"] == "L1\nL2\tT\rR"         # the value round-trips exactly
         end
+
+        @testset "clean values: unchanged, type-stable, allocation-free" begin
+            # #98 — a union-typed return would heap-box the clean-path SubString at every
+            # call site (one 32-byte box per attribute, in every reader's hot path).
+            clean = SubString("category=\"cat17\"", 11, 15)
+            @test XML._normalize_attr_ws(clean) === clean
+            @test only(Base.return_types(XML._normalize_attr_ws, (SubString{String},))) === SubString{String}
+            @test only(Base.return_types(XML._normalize_attr_ws, (String,))) === String
+            dirty = XML._normalize_attr_ws(SubString("a=\"p\tq\"", 4, 6))
+            @test dirty == "p q" && dirty isa SubString{String}
+            XML._normalize_attr_ws(clean)                # warm-up before measuring
+            if Base.JLOptions().code_coverage == 0       # coverage counters skew @allocated
+                @test (@allocated XML._normalize_attr_ws(clean)) == 0
+            end
+        end
     end
 
     @testset "Declaration attributes" begin


### PR DESCRIPTION
`_normalize_attr_ws` splits into the dirty scan (`_attr_ws_dirty`), the rewrite (`_rewrite_attr_ws`), and one façade method per input type: the `SubString{String}` method wraps its rare dirty rewrite back into a whole-string `SubString`, so both branches — and the inferred return — are concretely `SubString{String}`; the `AbstractString` fallback keeps the previous behavior for other input types. Call sites unchanged.

On the 14 MB XMark corpus (54 981 clean attribute values), `@allocated parse(S, Node)` returns to the v0.4.2 figure to the byte: 129 992 352 → **128 232 960 B**. A function-barrier micro-check measures **0 B** per clean call (32 B before).

Tests: the guard testset was committed RED first — concrete inferred return types for both input types, clean value handed back `===`, dirty value still normalized (now as a `SubString{String}`), and the barrier-measured allocation equal to 0, skipped under coverage whose counters skew `@allocated`. Full suite: 3549/3549, §3.3.3 semantics intact.

No CHANGELOG entry: this repairs a regression introduced by #96 within the same unreleased cycle — no released version ever shipped the box.