### PR TITLE
By-key attribute access on `FlatNode` and `Cursor`, `FlatNode` child-axis parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to XML.jl will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **By-key attribute access, completed across readers** — one rule: the key's type selects
+  the axis (an `Int` indexes the child sequence, `:` takes it whole, a `String` looks up the
+  attribute map, `get` being the default-on-a-miss variant). `FlatNode` gains
+  `n["key"]`/`get`/`haskey`/`keys` (attribute-range scan, only the matched value decoded)
+  plus the `n[:]`/`n[end]`/`only` child-axis forms; `Cursor` gains `getindex`/`haskey`/`keys`
+  beside its existing `get`, on the current node (#100).
+
 ## [0.4.3] - 2026-07-26
 
 ### Added
@@ -310,6 +321,7 @@ First release since XML.jl moved to [JuliaData](https://github.com/JuliaData/XML
 
 - Initial release.
 
+[Unreleased]: https://github.com/JuliaData/XML.jl/compare/v0.4.3...HEAD
 [0.4.3]: https://github.com/JuliaData/XML.jl/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/JuliaData/XML.jl/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/JuliaData/XML.jl/compare/v0.4.0...v0.4.1

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ is_simple(node)     -> Bool (e.g. <tag>text</tag>)
 simple_value(node)  -> e.g. "text" from <tag>text</tag>
 ```
 
+Indexing follows one rule across the tree readers (`Node`, `LazyNode`, `FlatNode`): the
+key's type selects the axis. An `Int` indexes the child sequence (`node[2]`, `node[end]`),
+`:` takes it whole (`node[:]`), and a `String` looks up the attribute map (`node["id"]`,
+`KeyError` on a miss) — with `get(node, "id", default)` as the default-on-a-miss variant,
+and `haskey`/`keys` alongside. `Cursor` supports the attribute forms on its current node.
+
 <br>
 
 ## `NodeType`

--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -216,6 +216,28 @@ function Base.get(c::Cursor, key::AbstractString, default)
     default
 end
 
+function Base.getindex(c::Cursor, key::AbstractString)
+    val = get(c, key, _MISSING_ATTR)
+    val === _MISSING_ATTR && throw(KeyError(key))
+    val
+end
+
+function Base.haskey(c::Cursor, key::AbstractString)
+    get(c, key, _MISSING_ATTR) !== _MISSING_ATTR
+end
+
+function Base.keys(c::Cursor)
+    c.nodetype in (Element, Declaration) || return ()
+    it = _rescan(c); iterate(it)
+    result = SubString{String}[]
+    for tok in it
+        tok.kind === _CURSOR_XT.TokenKinds.ATTR_NAME || break
+        push!(result, raw(tok, _data(c)))
+        iterate(it)                             # skip value
+    end
+    result
+end
+
 #-----------------------------------------------------------------------------# is_simple_value
 # Cursor mirror of `is_simple_value(::LazyNode)`: combined predicate+accessor that
 # returns the lone Text/CData value of the current element (or `nothing` if it has

--- a/src/flatnode.jl
+++ b/src/flatnode.jl
@@ -427,6 +427,55 @@ function Base.getindex(n::FlatNode, i::Integer)
     throw(BoundsError(n, i))
 end
 
+Base.getindex(n::FlatNode, ::Colon) = children(n)
+Base.lastindex(n::FlatNode) = length(n)
+Base.only(n::FlatNode) = only(children(n))
+
+"""
+    get(n::FlatNode, key::AbstractString, default)
+
+Return the value of attribute `key` on `n`, or `default` if absent. Scans the record's
+attribute range and decodes only the matched value — no vector materialized. Use
+[`attributes`](@ref) for all pairs at once.
+"""
+function Base.get(n::FlatNode, key::AbstractString, default)
+    r = _rec(n)
+    ai = r.attr_first
+    for _ in 1:r.attr_count
+        a = @inbounds n.store.attrs[ai]
+        if _fsub(n.store, a.name_offset, a.name_len) == key
+            rawv = _normalize_attr_ws(_fsub(n.store, a.value_offset, abs(a.value_len)))
+            return _as_substring(a.value_len < 0 ? unescape(rawv) : rawv)
+        end
+        ai += Int32(1)
+    end
+    default
+end
+
+function Base.getindex(n::FlatNode, key::AbstractString)
+    val = get(n, key, _MISSING_ATTR)
+    val === _MISSING_ATTR && throw(KeyError(key))
+    val
+end
+
+function Base.haskey(n::FlatNode, key::AbstractString)
+    get(n, key, _MISSING_ATTR) !== _MISSING_ATTR
+end
+
+function Base.keys(n::FlatNode)
+    r = _rec(n)
+    r.attr_count == 0 && return ()
+    out = SubString{String}[]
+    sizehint!(out, r.attr_count)
+    ai = r.attr_first
+    for _ in 1:r.attr_count
+        a = @inbounds n.store.attrs[ai]
+        push!(out, _fsub(n.store, a.name_offset, a.name_len))
+        ai += Int32(1)
+    end
+    out
+end
+
 is_simple(n::FlatNode) = (r = _rec(n);
     r.kind === Element && r.attr_count == 0 && r.first_child != 0 &&
     (c = @inbounds n.store.recs[r.first_child]; c.next_sibling == 0 && (c.kind === Text || c.kind === CData)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3187,7 +3187,7 @@ end
         # pair as ONE space — while white space written as character references survives.
         # Normalization happens on the raw slice, before entity resolution, uniformly
         # across the four readers.
-        getattr(x, name) = Dict(attributes(x))[name]
+        getattr(x, name) = x[name]      # uniform by-key access — exercises every reader's getindex
         function attr_by_reader(xml, name)
             n = getattr(only(elements(parse(xml, Node))), name)
             l = getattr(only(elements(parse(xml, LazyNode))), name)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3187,15 +3187,15 @@ end
         # pair as ONE space — while white space written as character references survives.
         # Normalization happens on the raw slice, before entity resolution, uniformly
         # across the four readers.
-        getattr(x, name) = x[name]      # uniform by-key access — exercises every reader's getindex
+        # by-key indexing throughout — exercises every reader's getindex
         function attr_by_reader(xml, name)
-            n = getattr(only(elements(parse(xml, Node))), name)
-            l = getattr(only(elements(parse(xml, LazyNode))), name)
-            f = getattr(only(elements(parse(xml, FlatNode))), name)
+            n = only(elements(parse(xml, Node)))[name]
+            l = only(elements(parse(xml, LazyNode)))[name]
+            f = only(elements(parse(xml, FlatNode)))[name]
             cur = Cursor(xml)
             c = nothing
             while next!(cur) !== nothing
-                nodetype(cur) === Element && (c = getattr(cur, name))
+                nodetype(cur) === Element && (c = cur[name])
             end
             (n, l, f, c)
         end

--- a/test/test_cursor.jl
+++ b/test/test_cursor.jl
@@ -53,6 +53,17 @@ using XML: Cursor, next!, for_each_child, @for_each_child, skip_element!, eof, n
         @test attrs["c"] == "<x>"
     end
 
+    @testset "by-key getindex/haskey/keys" begin
+        # #100 — the KeyError twin of `get`, plus haskey/keys, on the current node
+        c = parse(Cursor, """<root a="1" c="&lt;x&gt;"/>""")
+        next!(c)
+        @test c["a"] == "1"
+        @test c["c"] == "<x>"                            # entity-decoded
+        @test_throws KeyError c["missing"]
+        @test haskey(c, "a") && !haskey(c, "missing")
+        @test collect(keys(c)) == ["a", "c"]
+    end
+
     @testset "value of CData / Comment / PI / DTD / Text-with-entities" begin
         c = parse(Cursor, "<r><![CDATA[c<d>ata]]><!--cmt--><?pi body?><t>a&amp;b</t></r>")
         vals = Dict{Any,Any}()

--- a/test/test_flatnode.jl
+++ b/test/test_flatnode.jl
@@ -72,6 +72,33 @@ end
     @test occursin("Element", repr(root))                           # show smoke
 end
 
+@testset "by-key attribute access + child-axis parity" begin
+    # #100 — the key's type selects the axis, uniformly across the tree readers:
+    # an Int indexes the child sequence, `:` takes it whole, a String looks up the
+    # attribute map; get is the default-on-a-miss variant of the latter.
+    f = parse(RICH_XML, FlatNode)
+    root = only(eachelement(f))
+    els  = collect(eachelement(root))
+
+    # attribute axis: the get/getindex/haskey/keys quartet, decoded at access
+    @test root["a"] == "1"
+    @test els[2]["attr"] == "v<w"                       # entity-decoded on the way out
+    @test_throws KeyError root["absent"]
+    @test get(root, "a", nothing) == "1"
+    @test get(root, "absent", "dflt") == "dflt"
+    @test get(els[3], "any", nothing) === nothing       # <empty/>: no attributes
+    @test haskey(root, "a") && !haskey(root, "absent")
+    @test collect(keys(root)) == ["a", "b"]
+    @test keys(els[3]) == ()
+    lone = only(eachelement(parse("<a n=\"p\tq\"/>", FlatNode)))
+    @test lone["n"] == "p q"                            # §3.3.3 normalization applies here too
+
+    # child axis: Colon / end / only, parity with Node and LazyNode
+    @test root[:] == children(root)
+    @test root[end] == children(root)[end]
+    @test value(only(els[1])) == "plain"
+end
+
 @testset "structural ==/hash, positional issamenode" begin
     f = parse(RICH_XML, FlatNode)
     root = only(eachelement(f))


### PR DESCRIPTION
Closes #100.

The by-key quartet lands on both remaining readers. `FlatNode` gains `get` — a scan of the record's attribute range that stops at the match and decodes only that value, no vector materialized — with `getindex` via the `_MISSING_ATTR` sentinel, `haskey`, and `keys`, plus the child-axis forms `n[:]`, `n[end]` and `only` that `Node` and `LazyNode` already had. `Cursor` gains the `KeyError` twin of its existing `get`, `haskey`, and `keys` — a token walk over the current node, same shape as `LazyNode`'s.

This goes slightly beyond the issue's four methods, on purpose: the implementation mirrors the established idiom in full (`get` as the primitive; `getindex` = `get` + sentinel + `KeyError`; `haskey`/`keys` alongside), so the README claim "same read-only accessor surface" is now literally true and `n[end]` works on `FlatNode`.

Tests: guards committed RED first — the quartet on both readers (hit, `KeyError` on a miss, `get` default, entity decoding and §3.3.3 normalization through `getindex`) and the child-axis forms. Then the §3.3.3 four-reader matrix dropped its `Dict(attributes(x))[name]` workaround — the helper shim went entirely, the matrix indexes `x[name]` in place — so every normalization case now exercises the new accessors. Full suite: 3569/3569.

Docs: the indexing convention is stated in the README's interface section — the key's type selects the axis — and the CHANGELOG reopens `[Unreleased]` with the entry and its compare link.