### PR TITLE
Performance tables: `time (incl. GC)` with per-row GC share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The performance tables decompose garbage collection**: every timed row in
+  PERFORMANCE-v0.4.md now reads `total (GC x)` under a `time (incl. GC)` header — the total
+  is what a user lives, the GC share is the per-session draw, and their difference is the
+  reproducible work time. The benchmark harnesses (`profile.jl`, `flatnode_bench.jl`) print
+  the decomposition; `flatnode_bench.jl` reports the median run's own pair.
+
 ### Added
 
 - **By-key attribute access, completed across readers** — one rule: the key's type selects

--- a/PERFORMANCE-v0.4.md
+++ b/PERFORMANCE-v0.4.md
@@ -38,10 +38,10 @@ Performance isn't one number — it splits by *what you do with the document*. 1
 
 `Cursor` pulls in pure Julia; EzXML's `StreamReader` is libxml2's reader, paying FFI per event:
 
-| Stream | time | memory |
+| Stream | time (incl. GC) | memory |
 |---|--:|--:|
-| **XML.jl `Cursor`** | **54 ms** | **17 MiB** |
-| EzXML `StreamReader` | 67 ms | 35 MiB |
+| **XML.jl `Cursor`** | **53 ms** (GC 0.6) | **17 MiB** |
+| EzXML `StreamReader` | 66 ms (GC 1.2) | 35 MiB |
 
 _Table 1 — streaming: events only, no tree built._[^profile]
 
@@ -68,28 +68,28 @@ Opening is a no-op wrapper (~0.5 µs on this 14 MB file) and nothing is ever cac
 
 libxml2 wins the build; XML.jl materialises an 882 K-node Julia tree, EzXML a leaner C one:
 
-| Full DOM extract | time | memory |
+| Full DOM extract | time (incl. GC) | memory |
 |---|--:|--:|
 | EzXML (libxml2) | **61 ms** | **54 MiB** |
-| LightXML (elements only) | 63 ms | 57 MiB |
-| XML.jl (`SubString`, zero-copy) | 103 ms | 120 MiB |
-| XML.jl (`String`) | 115 ms | 122 MiB |
+| LightXML (elements only) | 62 ms (GC 1.5) | 57 MiB |
+| XML.jl (`SubString`, zero-copy) | 115 ms (GC 39) | 120 MiB |
+| XML.jl (`String`) | 136 ms (GC 45) | 122 MiB |
 | XML.jl **v0.3.9** (previous release) | 530 ms | 1422 MiB |
 
 _Table 2 — full-DOM extraction (parse + pull every tag/text), cross-library._[^profile]
 
-**Decomposed** (XML.jl, the `String` variant — the stages sum to its Table 2 row):
+**Decomposed** (XML.jl, the `String` variant — subtract each row's GC share and the stages sum to the Table 2 row's own GC-free time, within noise):
 
-| Stage | time | allocated |
+| Stage | time (incl. GC) | allocated |
 |---|--:|--:|
 | read file (I/O) | 0.6 ms | — |
-| **lex — the DFA** | **36 ms** | **0 B** |
-| build the tree — the VPA | ~73 ms | 122 MiB |
-| traverse a built tree | 7 ms | 0 B |
+| **lex — the DFA** | **36.8 ms** | **0 B** |
+| build the tree — the VPA | ~68 ms (GC 22) | 122 MiB |
+| traverse a built tree | 6.1 ms | 0 B |
 
 _Table 3 — the XML.jl pipeline, decomposed (`String` variant)._[^profile]
 
-The lexer is allocation-free; **the whole libxml2 gap is *materialising* the native tree, not scanning it**. Nor are the build's ~73 ms all construction: ~26 ms *of* them are garbage-collector pauses (BenchmarkTools' per-sample GC time) — the allocation-free lex cannot trigger a collection, so every GC pause inside a parse lands in the build, the toll of 882 K fresh objects.
+The lexer is allocation-free; **the whole libxml2 gap is *materialising* the native tree, not scanning it** — and the GC column shows where that cost lives: the allocation-free lex cannot trigger a collection, so every garbage-collector pause inside a parse lands in the build, the toll of 882 K fresh objects. The GC share is also the *volatile* part of these numbers: it moves with the heap state a session inherits (this page has measured the `String` extraction's total anywhere from 115 to 137 ms), while the GC-free remainder reproduces within a few percent.
 
 ### `FlatNode` (v0.4.2, experimental)
 
@@ -105,23 +105,23 @@ And the scan is [*cache-oblivious*](https://en.wikipedia.org/wiki/Cache-obliviou
 
 Measured on the same XMark document:
 
-| Full DOM, per reader | build | walk every node | extract all values | DOM size in memory |
+| Full DOM, per reader | build (incl. GC) | walk every node | extract all values | DOM size in memory |
 |---|--:|--:|--:|--:|
-| **`FlatNode`** | **51.8 ms** | **2.97 ms** | 10.6 ms | **54.9 MiB** |
-| `Node` | 99.9 ms | 6.3 ms | **6.5 ms** | 80.0 MiB |
-| EzXML (libxml2) | 37.7 ms | — | — | — |
+| **`FlatNode`** | **53.6 ms** | **2.96 ms** | 9.3 ms | **54.9 MiB** |
+| `Node` | 93.4 ms (GC 15.1) | 5.2 ms | **5.3 ms** | 80.0 MiB |
+| EzXML (libxml2) | 37.8 ms | — | — | — |
 
-_Table 4 — per-reader full-DOM comparison (median of repeated runs, default settings); *build* is the whole `parse` call, and *DOM size* is the **retained** live tree (`Base.summarysize`), not allocations._[^flatbench]
+_Table 4 — per-reader full-DOM comparison (median run of 7, default settings); *build* is the whole `parse` call, and *DOM size* is the **retained** live tree (`Base.summarysize`), not allocations._[^flatbench]
 
-Build allocations: 73.7 MiB (`FlatNode`) vs 122.3 MiB (`Node`), and the libxml2 *build* gap narrows from ~2.7× to ~1.4×. Beyond the cheaper build, access itself is faster on `FlatNode`: full walks run ~2× faster (the contiguous scan), and `parent`/`depth` are O(1) index hops where `Node` must search down from the root. The one pattern where `Node` keeps an edge is pure value extraction on an already-built tree (6.5 vs 10.6 ms): direct field reads beat computed `SubString` views.
+Build allocations: 73.7 MiB (`FlatNode`) vs 122.3 MiB (`Node`), and the libxml2 *build* gap narrows from ~2.5× to ~1.4×. Note the GC cells: on a freshly collected heap, `FlatNode`'s build triggers *no* collection at all — a handful of arrays instead of 882 K objects — where `Node`'s pays 15 ms of GC inside the same corpus. Beyond the cheaper build, access itself is faster on `FlatNode`: full walks run ~1.8× faster (the contiguous scan), and `parent`/`depth` are O(1) index hops where `Node` must search down from the root. The one pattern where `Node` keeps an edge is pure value extraction on an already-built tree (5.3 vs 9.3 ms): direct field reads beat computed `SubString` views.
 
 ### Choosing
 
-Stream / low-memory / read-only full-DOM / repeated traversal → **XML.jl**; a one-shot build-and-extract is the one job where a libxml2 binder still builds ~1.4× faster (was ~2.7× before `FlatNode`) — either way, pure Julia, no C dependency. Against its own past, v0.4 is **~5× faster and ~12× leaner than 0.3.9** (which used ~1.4 GiB for this file) — see [`benchmarks/profile.jl`](benchmarks/profile.jl), [`benchmarks/profile_vs_039.jl`](benchmarks/profile_vs_039.jl), [`benchmarks/compare.jl`](benchmarks/compare.jl).
+Stream / low-memory / read-only full-DOM / repeated traversal → **XML.jl**; a one-shot build-and-extract is the one job where a libxml2 binder still builds ~1.4× faster (was ~2.5× before `FlatNode`) — either way, pure Julia, no C dependency. Against its own past, v0.4 is **~5× faster and ~12× leaner than 0.3.9** (which used ~1.4 GiB for this file) — see [`benchmarks/profile.jl`](benchmarks/profile.jl), [`benchmarks/profile_vs_039.jl`](benchmarks/profile_vs_039.jl), [`benchmarks/compare.jl`](benchmarks/compare.jl).
 
 > [!NOTE]
 > **`:strict`** adds a character-range scan over text (a second O(content) pass); the overhead scales with the document's *text share* — ~1.1× on the markup-heavy XMark corpus, up to ~20× on a pure-text document; `:lenient` / `:structural` are unaffected.
 
-[^profile]: Tables 1–3: measured 2026-07-22 (the `v0.3.9` row: 2026-06-28), Apple M5 (single-threaded), Julia 1.12.6; EzXML 1.2.3 / LightXML 0.9.3 (libxml2 2.15.3). Source: [`benchmarks/profile.jl`](benchmarks/profile.jl).
+[^profile]: Tables 1–3: measured 2026-07-27 (the `v0.3.9` row: 2026-06-28), Apple M5 (single-threaded), Julia 1.12.6; EzXML 1.2.3 / LightXML 0.9.3 (libxml2 2.15.3). Each time is the median sample's total, its *(GC x)* tail that same sample's garbage-collection share — omitted when below 0.05 ms; the total minus it is the GC-free work, the reproducible part of the number. Source: [`benchmarks/profile.jl`](benchmarks/profile.jl).
 
-[^flatbench]: Table 4: measured 2026-07-22, same machine and Julia; source [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl).
+[^flatbench]: Table 4: measured 2026-07-27, same machine and Julia; source [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl) — each cell is the median run of 7, every run starting from a freshly collected heap, so its *(GC x)* tail is that run's own allocation cost, not inherited debt.

--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ Source: [`benchmarks/benchmarks.jl`](benchmarks/benchmarks.jl). Data: `books.xml
 | Collect tags, medium | 5.63 ms | 10.4 ms | 12.9 ms | — |
 
 EzXML and LightXML wrap libxml2 (C): faster on raw parse, slower on in-Julia traversal.
+Times include garbage collection; [PERFORMANCE](PERFORMANCE-v0.4.md) breaks each of its rows
+into the stable GC-free work and the per-session GC share.
 
 For the per-access-pattern decomposition (streaming / partial reads / full DOM / stage breakdown) and the theory behind these numbers, see [**PERFORMANCE-v0.4.md**](PERFORMANCE-v0.4.md).
 

--- a/benchmarks/flatnode_bench.jl
+++ b/benchmarks/flatnode_bench.jl
@@ -11,7 +11,15 @@ const xmark = joinpath(@__DIR__, "data", "xmark.xml")
 const xml = read(xmark, String)
 println("corpus: ", basename(xmark), " (", round(ncodeunits(xml) / 2^20, digits = 1), " MiB)")
 
-medN(f, n = 7) = median((GC.gc(); @elapsed f()) for _ in 1:n)
+# The median RUN's (elapsed, gctime) pair — runs sorted by elapsed, middle one picked whole,
+# so the GC figure belongs to the same run as the time it decomposes. GC.gc() first: each run
+# starts from a clean heap, so gctime is the run's own allocation cost, not inherited debt.
+function medN(f, n = 7)
+    runs = [begin GC.gc(); t = @timed f(); (t.time, t.gctime) end for _ in 1:n]
+    sort!(runs; by = first)
+    runs[cld(n, 2)]
+end
+_gctail(gc) = gc * 1000 < 0.05 ? "" : string(" (GC ", round(gc * 1000, digits = 1), ")")
 allocs(f) = (GC.gc(); Base.gc_num().allocd; a0 = Base.gc_bytes(); f(); Base.gc_bytes() - a0)
 
 # ── build ──
@@ -19,7 +27,8 @@ fbuild() = parse(xml, FlatNode)
 nbuild() = parse(xml, Node)
 ezbuild() = EzXML.parsexml(xml)
 for (nm, f) in ["FlatNode" => fbuild, "Node" => nbuild, "EzXML" => ezbuild]
-    println("build   ", rpad(nm, 9), lpad(round(medN(f) * 1000, digits = 1), 8), " ms")
+    el, gc = medN(f)
+    println("build   ", rpad(nm, 9), lpad(round(el * 1000, digits = 1), 8), " ms", _gctail(gc))
 end
 
 # ── traverse (count nodes via each reader's handles) ──
@@ -47,7 +56,8 @@ function curwalk()
 end
 println("nodes: flat=", fwalk(FlatNode(F.store, Int32(1))), " node=", nwalk(N), " lazy=", lwalk(L))
 for (nm, f) in ["FlatNode" => () -> fwalk(FlatNode(F.store, Int32(1))), "Node" => () -> nwalk(N), "Cursor" => curwalk, "LazyNode" => () -> lwalk(L)]
-    println("walk    ", rpad(nm, 9), lpad(round(medN(f) * 1000, digits = 2), 8), " ms")
+    el, gc = medN(f)
+    println("walk    ", rpad(nm, 9), lpad(round(el * 1000, digits = 2), 8), " ms", _gctail(gc))
 end
 
 # ── extract (tag/value byte sums through the public accessors) ──
@@ -65,7 +75,8 @@ function nextract(n, acc = Ref(0))
 end
 println("extract sums: flat=", fextract(FlatNode(F.store, Int32(1))), " node=", nextract(N))
 for (nm, f) in ["FlatNode" => () -> fextract(FlatNode(F.store, Int32(1))), "Node" => () -> nextract(N)]
-    println("extract ", rpad(nm, 9), lpad(round(medN(f) * 1000, digits = 2), 8), " ms")
+    el, gc = medN(f)
+    println("extract ", rpad(nm, 9), lpad(round(el * 1000, digits = 2), 8), " ms", _gctail(gc))
 end
 
 # ── retained + build allocations ──

--- a/benchmarks/profile.jl
+++ b/benchmarks/profile.jl
@@ -30,7 +30,13 @@ const SSNode = Node{SubString{String}}
 
 ms(b)  = round(median(b).time / 1e6, digits = 2)
 mib(b) = round(b.memory / 2^20, digits = 1)
-row(label, b) = println(rpad("  " * label, 26), lpad(ms(b), 8), " ms   ", lpad(mib(b), 7), " MiB")
+# Each line decomposes its median: total (the user-lived figure, GC draws included) and the
+# GC share of that median sample — the total minus it is the stable, reproducible work time.
+function row(label, b)
+    gc = median(b).gctime / 1e6
+    tail = gc < 0.05 ? "" : string(" (GC ", round(gc, digits = 1), ")")
+    println(rpad("  " * label, 26), lpad(ms(b), 8), " ms", rpad(tail, 12), lpad(mib(b), 7), " MiB")
+end
 
 #--------------------------------------------------------------# (1) STREAM (no tree)
 # Advance through every node touching tag + value — the streaming workload, zero tree built.


### PR DESCRIPTION
Closes #102.

Every timed row now reads `total (GC x)` under a `time (incl. GC)` header: the total remains the user-lived figure, the tail is the median sample's GC share, and their difference is the stable work. The decomposition applies to every library's row alike — which is the point: EzXML's extraction runs with no measurable Julia GC (its tree lives on the C heap), so the table now shows that a third of XML.jl's full-DOM total is collector time rather than parsing; and on a freshly collected heap, `FlatNode`'s build triggers no collection at all where `Node`'s pays 15 ms inside the same corpus — the GC cells carry the `FlatNode` argument on their own.

Harnesses: `profile.jl` prints the median sample's pair; `flatnode_bench.jl`'s `medN` returns the median run's own (elapsed, gctime) — runs sorted by elapsed, the middle one picked whole, each starting from a freshly collected heap. Tables 1–4 are regenerated from one fresh session (2026-07-27); the stages-sum claim is restated on GC-free time, where it verifiably holds; the footnotes document both protocols; the README table keeps totals with one pointer sentence. CHANGELOG under Unreleased/Changed.