### PR TITLE
Make the decoded read surface allocation-free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   phenomenon the v0.4.3 normalization fix removed (#98): `unescape`'s union return, the
   `getindex` sentinel default, and small unions crossing non-inlined call boundaries.
   `simple_value(::LazyNode)` now runs the same single-pass token walk as
-  `is_simple_value` instead of materializing `attributes` and `children`. Allocation
-  guards in the test suite pin every accessor at zero (#105).
+  `is_simple_value` instead of materializing `attributes` and `children`. On the 14 MB
+  benchmark corpus, a full `Cursor` streaming pass now allocates nothing at all (was
+  17 MiB) and runs ~14 % faster, and the `FlatNode` value-extraction stage drops ~30 %
+  (9.3 → 6.6 ms). Allocation guards in the test suite pin every accessor at zero (#105).
 - **`foreach_attr`'s docstring no longer recommends the internal tokenizer layer**
   (`XML.XMLTokenizer.raw`/`attr_value`) — a workaround from before the decoded surface
   was allocation-free, and a semantic trap: `attr_value` only strips the quotes,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plus the `n[:]`/`n[end]`/`only` child-axis forms; `Cursor` gains `getindex`/`haskey`/`keys`
   beside its existing `get`, on the current node (#100).
 
+### Fixed
+
+- **The decoded read surface is now allocation-free** on the three zero-copy readers
+  (`LazyNode`, `FlatNode`, `Cursor`): `n["key"]`/`get`/`haskey`, `value`,
+  `simple_value`/`is_simple_value` and `eachattribute` no longer heap-box their result on
+  entity-free content — previously 32–320 B on every call, the same type-instability
+  phenomenon the v0.4.3 normalization fix removed (#98): `unescape`'s union return, the
+  `getindex` sentinel default, and small unions crossing non-inlined call boundaries.
+  `simple_value(::LazyNode)` now runs the same single-pass token walk as
+  `is_simple_value` instead of materializing `attributes` and `children`. Allocation
+  guards in the test suite pin every accessor at zero (#105).
+- **`foreach_attr`'s docstring no longer recommends the internal tokenizer layer**
+  (`XML.XMLTokenizer.raw`/`attr_value`) — a workaround from before the decoded surface
+  was allocation-free, and a semantic trap: `attr_value` only strips the quotes,
+  performing no character-reference resolution and no XML 1.0 §3.3.3 white-space
+  normalization. The docstring now points to `eachattribute` (decoded, equally
+  allocation-free) and spells out the raw-layer caveat (#104).
+
 ## [0.4.3] - 2026-07-26
 
 ### Added

--- a/PERFORMANCE-v0.4.md
+++ b/PERFORMANCE-v0.4.md
@@ -36,12 +36,13 @@ Performance isn't one number — it splits by *what you do with the document*. 1
 
 ### Stream — events, no tree
 
-`Cursor` pulls in pure Julia; EzXML's `StreamReader` is libxml2's reader, paying FFI per event:
+`Cursor` pulls in pure Julia — a full pass, decoded reads included, leaves the allocator
+untouched; EzXML's `StreamReader` is libxml2's reader, paying FFI per event:
 
 | Stream | time (incl. GC) | memory |
 |---|--:|--:|
-| **XML.jl `Cursor`** | **53 ms** (GC 0.6) | **17 MiB** |
-| EzXML `StreamReader` | 66 ms (GC 1.2) | 35 MiB |
+| **XML.jl `Cursor`** | **46 ms** | **0.0 MiB** |
+| EzXML `StreamReader` | 68 ms (GC 1.3) | 36 MiB |
 
 _Table 1 — streaming: events only, no tree built._[^profile]
 
@@ -70,10 +71,10 @@ libxml2 wins the build; XML.jl materialises an 882 K-node Julia tree, EzXML a le
 
 | Full DOM extract | time (incl. GC) | memory |
 |---|--:|--:|
-| EzXML (libxml2) | **61 ms** | **54 MiB** |
-| LightXML (elements only) | 62 ms (GC 1.5) | 57 MiB |
-| XML.jl (`SubString`, zero-copy) | 115 ms (GC 39) | 120 MiB |
-| XML.jl (`String`) | 136 ms (GC 45) | 122 MiB |
+| EzXML (libxml2) | **63 ms** | **54 MiB** |
+| LightXML (elements only) | 63 ms (GC 1.5) | 57 MiB |
+| XML.jl (`SubString`, zero-copy) | 117 ms (GC 41) | 120 MiB |
+| XML.jl (`String`) | 143 ms (GC 45) | 122 MiB |
 | XML.jl **v0.3.9** (previous release) | 530 ms | 1422 MiB |
 
 _Table 2 — full-DOM extraction (parse + pull every tag/text), cross-library._[^profile]
@@ -83,13 +84,13 @@ _Table 2 — full-DOM extraction (parse + pull every tag/text), cross-library._[
 | Stage | time (incl. GC) | allocated |
 |---|--:|--:|
 | read file (I/O) | 0.6 ms | — |
-| **lex — the DFA** | **36.8 ms** | **0 B** |
-| build the tree — the VPA | ~68 ms (GC 22) | 122 MiB |
-| traverse a built tree | 6.1 ms | 0 B |
+| **lex — the DFA** | **36.5 ms** | **0 B** |
+| build the tree — the VPA | ~76 ms (GC 28) | 122 MiB |
+| traverse a built tree | 6.4 ms | 0 B |
 
 _Table 3 — the XML.jl pipeline, decomposed (`String` variant)._[^profile]
 
-The lexer is allocation-free; **the whole libxml2 gap is *materialising* the native tree, not scanning it** — and the GC column shows where that cost lives: the allocation-free lex cannot trigger a collection, so every garbage-collector pause inside a parse lands in the build, the toll of 882 K fresh objects. The GC share is also the *volatile* part of these numbers: it moves with the heap state a session inherits (this page has measured the `String` extraction's total anywhere from 115 to 137 ms), while the GC-free remainder reproduces within a few percent.
+The lexer is allocation-free; **the whole libxml2 gap is *materialising* the native tree, not scanning it** — and the GC column shows where that cost lives: the allocation-free lex cannot trigger a collection, so every garbage-collector pause inside a parse lands in the build, the toll of 882 K fresh objects. The GC share is also the *volatile* part of these numbers: it moves with the heap state a session inherits (this page has measured the `String` extraction's total anywhere from 115 to 143 ms), while the GC-free remainder reproduces within a few percent.
 
 ### `FlatNode` (v0.4.2, experimental)
 
@@ -107,13 +108,13 @@ Measured on the same XMark document:
 
 | Full DOM, per reader | build (incl. GC) | walk every node | extract all values | DOM size in memory |
 |---|--:|--:|--:|--:|
-| **`FlatNode`** | **53.6 ms** | **2.96 ms** | 9.3 ms | **54.9 MiB** |
-| `Node` | 93.4 ms (GC 15.1) | 5.2 ms | **5.3 ms** | 80.0 MiB |
+| **`FlatNode`** | **52.1 ms** | **2.94 ms** | 6.6 ms | **54.9 MiB** |
+| `Node` | 93.4 ms (GC 15.4) | 5.2 ms | **5.4 ms** | 80.0 MiB |
 | EzXML (libxml2) | 37.8 ms | — | — | — |
 
 _Table 4 — per-reader full-DOM comparison (median run of 7, default settings); *build* is the whole `parse` call, and *DOM size* is the **retained** live tree (`Base.summarysize`), not allocations._[^flatbench]
 
-Build allocations: 73.7 MiB (`FlatNode`) vs 122.3 MiB (`Node`), and the libxml2 *build* gap narrows from ~2.5× to ~1.4×. Note the GC cells: on a freshly collected heap, `FlatNode`'s build triggers *no* collection at all — a handful of arrays instead of 882 K objects — where `Node`'s pays 15 ms of GC inside the same corpus. Beyond the cheaper build, access itself is faster on `FlatNode`: full walks run ~1.8× faster (the contiguous scan), and `parent`/`depth` are O(1) index hops where `Node` must search down from the root. The one pattern where `Node` keeps an edge is pure value extraction on an already-built tree (5.3 vs 9.3 ms): direct field reads beat computed `SubString` views.
+Build allocations: 73.7 MiB (`FlatNode`) vs 122.3 MiB (`Node`), and the libxml2 *build* gap narrows from ~2.5× to ~1.4×. Note the GC cells: on a freshly collected heap, `FlatNode`'s build triggers *no* collection at all — a handful of arrays instead of 882 K objects — where `Node`'s pays 15 ms of GC inside the same corpus. Beyond the cheaper build, access itself is faster on `FlatNode`: full walks run ~1.8× faster (the contiguous scan), and `parent`/`depth` are O(1) index hops where `Node` must search down from the root. The one pattern where `Node` keeps an edge is pure value extraction on an already-built tree (5.4 vs 6.6 ms): direct field reads still beat computed `SubString` views, though only by ~20 % now that the decoded accessors return their views unboxed.
 
 ### Choosing
 
@@ -122,6 +123,6 @@ Stream / low-memory / read-only full-DOM / repeated traversal → **XML.jl**; a 
 > [!NOTE]
 > **`:strict`** adds a character-range scan over text (a second O(content) pass); the overhead scales with the document's *text share* — ~1.1× on the markup-heavy XMark corpus, up to ~20× on a pure-text document; `:lenient` / `:structural` are unaffected.
 
-[^profile]: Tables 1–3: measured 2026-07-27 (the `v0.3.9` row: 2026-06-28), Apple M5 (single-threaded), Julia 1.12.6; EzXML 1.2.3 / LightXML 0.9.3 (libxml2 2.15.3). Each time is the median sample's total, its *(GC x)* tail that same sample's garbage-collection share — omitted when below 0.05 ms; the total minus it is the GC-free work, the reproducible part of the number. Source: [`benchmarks/profile.jl`](benchmarks/profile.jl).
+[^profile]: Tables 1–3: measured 2026-07-30 (the `v0.3.9` row: 2026-06-28), Apple M5 (single-threaded), Julia 1.12.6; EzXML 1.2.3 / LightXML 0.9.3 (libxml2 2.15.3). Each time is the median sample's total, its *(GC x)* tail that same sample's garbage-collection share — omitted when below 0.05 ms; the total minus it is the GC-free work, the reproducible part of the number. Source: [`benchmarks/profile.jl`](benchmarks/profile.jl).
 
-[^flatbench]: Table 4: measured 2026-07-27, same machine and Julia; source [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl) — each cell is the median run of 7, every run starting from a freshly collected heap, so its *(GC x)* tail is that run's own allocation cost, not inherited debt.
+[^flatbench]: Table 4: measured 2026-07-30, same machine and Julia; source [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl) — each cell is the median run of 7, every run starting from a freshly collected heap, so its *(GC x)* tail is that run's own allocation cost, not inherited debt.

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ doc = read("file.xml", LazyNode)
 
 `LazyNode` supports the same read-only interface as `Node`: `nodetype`, `tag`, `attributes`, `value`, `children`, `is_simple`, `simple_value`, plus integer and string indexing.
 
-`LazyNode` is for *partial* reads only: opening is a no-op wrapper (~0.5 µs whatever the file size), a traversal pays only for the bytes it steps over — descending to a target is O(bytes before it), so reaching this 14 MB file's root element costs ~4 µs — and nothing is cached, so repeated visits pay again. Unbeatable for descents and kilobyte-scale documents; for whole-tree walks (276 ms vs ~55/~106 ms build+walk on the 14 MB corpus below) and repeated queries, build `FlatNode` or `Node` instead — see [Performance by access pattern](#performance-by-access-pattern).
+`LazyNode` is for *partial* reads only: opening is a no-op wrapper (~0.5 µs whatever the file size), a traversal pays only for the bytes it steps over — descending to a target is O(bytes before it), so reaching this 14 MB file's root element costs ~4 µs — and nothing is cached, so repeated visits pay again. Unbeatable for descents and kilobyte-scale documents; for whole-tree walks (283 ms vs ~55/~99 ms build+walk on the 14 MB corpus below) and repeated queries, build `FlatNode` or `Node` instead — see [Performance by access pattern](#performance-by-access-pattern).
 
 For streaming and high-throughput workloads, several extra accessors avoid materializing intermediate collections:
 
@@ -333,19 +333,19 @@ end
 
 # Performance by access pattern
 
-One number cannot rank the readers — cost depends on what you do with the document. Same ~14 MB / 882 K-node XMark document as the cross-library table below, XML.jl v0.4.2 (source: [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl); **lower is better**; median of repeated runs at the default settings):
+One number cannot rank the readers — cost depends on what you do with the document. Same ~14 MB / 882 K-node XMark document as the cross-library table below (source: [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl); **lower is better**; median of repeated runs at the default settings):
 
 | | build | walk every node | extract all values | DOM size in memory |
 |---|--:|--:|--:|--:|
-| `Cursor` | — (streams) | 35.1 ms (its one scan) | — | — (no DOM) |
-| `LazyNode` | ~0 (a wrapper) | 276 ms (re-tokenizes) | — | — (source only) |
-| `FlatNode` | 51.8 ms | 3.0 ms | 10.6 ms | 54.9 MiB |
-| `Node` | 99.9 ms | 6.3 ms | 6.5 ms | 80.0 MiB |
-| EzXML (libxml2) | 37.7 ms | — | — | — |
+| `Cursor` | — (streams) | 35.7 ms (its one scan) | — | — (no DOM) |
+| `LazyNode` | ~0 (a wrapper) | 283 ms (re-tokenizes) | — | — (source only) |
+| `FlatNode` | 52.1 ms | 2.9 ms | 6.6 ms | 54.9 MiB |
+| `Node` | 93.4 ms | 5.2 ms | 5.4 ms | 80.0 MiB |
+| EzXML (libxml2) | 37.8 ms | — | — | — |
 
-Reading the table: `Cursor`'s walk *is* its parse — one tokenizing scan, nothing retained. `LazyNode` opens for free and pays per node visited — unbeatable for touching a *fraction* of a large document, and (as the walk column shows) the wrong tool for visiting all of it. `FlatNode` builds ~2× faster than `Node`, walks ~2× faster, holds ~30% less memory, and its `parent`/`depth` are O(1) where `Node` searches from the root; pure value extraction on an already-built tree is the one pattern where `Node`'s direct fields win. libxml2 still builds fastest — the remaining gap is materialization, not scanning (see [PERFORMANCE-v0.4.md](PERFORMANCE-v0.4.md)).
+Reading the table: `Cursor`'s walk *is* its parse — one tokenizing scan, nothing retained. `LazyNode` opens for free and pays per node visited — unbeatable for touching a *fraction* of a large document, and (as the walk column shows) the wrong tool for visiting all of it. `FlatNode` builds ~1.8× faster than `Node`, walks ~1.8× faster, holds ~30% less memory, and its `parent`/`depth` are O(1) where `Node` searches from the root; pure value extraction on an already-built tree is the one pattern where `Node`'s direct fields still win, now by ~20%. libxml2 still builds fastest — the remaining gap is materialization, not scanning (see [PERFORMANCE-v0.4.md](PERFORMANCE-v0.4.md)).
 
-_Measured 2026-07-22, Apple M5 (single-threaded), Julia 1.12.6, EzXML 1.2.3._
+_Measured 2026-07-30, Apple M5 (single-threaded), Julia 1.12.6, EzXML 1.2.3._
 
 <br>
 

--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -148,13 +148,12 @@ function tag(c::Cursor)
     nt === ProcessingInstruction  ? pi_target(c.token, _data(c)) : nothing
 end
 
-# token-layer entity decode (inlined `_decode`; depends only on `unescape`).
-# Returns Union{SubString,String} like `value(::LazyNode)` — the polymorphic
-# return is inherent to the accessor; the residual boxing it causes is minor
-# next to the per-token allocation that Phase 2 (bitstype Token) removes.
+# token-layer entity decode (inlined `_decode`; depends only on `unescape`, whose
+# `SubString` method returns concretely — both branches here are `SubString{String}`).
 @inline _cursor_decode(tok, data) = tok.has_entities ? unescape(raw(tok, data)) : raw(tok, data)
 
-function value(c::Cursor)
+# @inline: keeps the union return caller-splittable — see the note on `value(::LazyNode)`.
+@inline function value(c::Cursor)
     nt = c.nodetype
     if nt === Text
         return _cursor_decode(c.token, _data(c))
@@ -182,8 +181,6 @@ end
     v = _normalize_attr_ws(attr_value(tok, data))
     tok.has_entities ? unescape(v) : v
 end
-@inline _cursor_as_substring(s::SubString{String}) = s
-@inline _cursor_as_substring(s::String) = SubString(s, 1, lastindex(s))
 
 function attributes(c::Cursor)
     c.nodetype in (Element, Declaration) || return nothing
@@ -194,13 +191,13 @@ function attributes(c::Cursor)
         name = raw(tok, _data(c))
         r = iterate(it)
         r === nothing && break
-        push!(attrs, name => _cursor_as_substring(_cursor_decode_attr(r[1], _data(c))))
+        push!(attrs, name => _cursor_decode_attr(r[1], _data(c)))
     end
     isempty(attrs) ? nothing : Attributes(attrs)
 end
 
 # Single-attribute read with no `Attributes` allocation.
-function Base.get(c::Cursor, key::AbstractString, default)
+@inline function Base.get(c::Cursor, key::AbstractString, default)
     c.nodetype in (Element, Declaration) || return default
     it = _rescan(c); iterate(it)
     for tok in it
@@ -216,15 +213,13 @@ function Base.get(c::Cursor, key::AbstractString, default)
     default
 end
 
-function Base.getindex(c::Cursor, key::AbstractString)
-    val = get(c, key, _MISSING_ATTR)
-    val === _MISSING_ATTR && throw(KeyError(key))
+@inline function Base.getindex(c::Cursor, key::AbstractString)
+    val = get(c, key, nothing)
+    val === nothing && throw(KeyError(key))
     val
 end
 
-function Base.haskey(c::Cursor, key::AbstractString)
-    get(c, key, _MISSING_ATTR) !== _MISSING_ATTR
-end
+@inline Base.haskey(c::Cursor, key::AbstractString) = get(c, key, nothing) !== nothing
 
 function Base.keys(c::Cursor)
     c.nodetype in (Element, Declaration) || return ()
@@ -244,7 +239,7 @@ end
 # attributes / isn't a single-text element). Non-destructive — reads via `_rescan`,
 # so the cursor position is unchanged (caller still advances with `for_each_child` /
 # `skip_element!`). Lets hot paths read e.g. an XLSX `<v>` value with no LazyNode snapshot.
-function is_simple_value(c::Cursor)
+@inline function is_simple_value(c::Cursor)
     c.nodetype === Element || return nothing
     it = _rescan(c)
     iterate(it)                                 # skip OPEN_TAG

--- a/src/escape.jl
+++ b/src/escape.jl
@@ -40,7 +40,7 @@ end
 
 """
     unescape(x::AbstractString) -> String
-    unescape(x::SubString{String}) -> Union{SubString{String}, String}
+    unescape(x::SubString{String}) -> SubString{String}
 
 Unescape XML entities in `x`: the five predefined entities (`&amp;` `&lt;` `&gt;` `&apos;`
 `&quot;`) and numeric character references (`&#123;`, `&#xAB;`). Each reference is processed
@@ -94,8 +94,12 @@ function _rewrite_attr_ws(s::AbstractString)
     String(take!(io))
 end
 
+# The rewrite result is wrapped back into `SubString` so both paths return the same
+# concrete type: every reader's decode funnel calls this on its hot path, and a
+# `Union{SubString{String}, String}` return would heap-box the dominant clean-path
+# SubString at every non-inlined call site — one 32-byte box per read (#98, #105).
 function unescape(x::SubString{String})
     occursin('&', x) || return x
-    replace(String(x), _ENTITY_RE => _unescape_entity)
+    SubString(replace(String(x), _ENTITY_RE => _unescape_entity))
 end
 

--- a/src/flatnode.jl
+++ b/src/flatnode.jl
@@ -307,8 +307,7 @@ function attributes(n::FlatNode)
         a = @inbounds n.store.attrs[ai]
         name = _fsub(n.store, a.name_offset, a.name_len)
         rawv = _normalize_attr_ws(_fsub(n.store, a.value_offset, abs(a.value_len)))
-        val = _as_substring(a.value_len < 0 ? unescape(rawv) : rawv)
-        push!(out, name => val)
+        push!(out, name => (a.value_len < 0 ? unescape(rawv) : rawv))
         ai += Int32(1)
     end
     out
@@ -438,29 +437,27 @@ Return the value of attribute `key` on `n`, or `default` if absent. Scans the re
 attribute range and decodes only the matched value — no vector materialized. Use
 [`attributes`](@ref) for all pairs at once.
 """
-function Base.get(n::FlatNode, key::AbstractString, default)
+@inline function Base.get(n::FlatNode, key::AbstractString, default)
     r = _rec(n)
     ai = r.attr_first
     for _ in 1:r.attr_count
         a = @inbounds n.store.attrs[ai]
         if _fsub(n.store, a.name_offset, a.name_len) == key
             rawv = _normalize_attr_ws(_fsub(n.store, a.value_offset, abs(a.value_len)))
-            return _as_substring(a.value_len < 0 ? unescape(rawv) : rawv)
+            return a.value_len < 0 ? unescape(rawv) : rawv
         end
         ai += Int32(1)
     end
     default
 end
 
-function Base.getindex(n::FlatNode, key::AbstractString)
-    val = get(n, key, _MISSING_ATTR)
-    val === _MISSING_ATTR && throw(KeyError(key))
+@inline function Base.getindex(n::FlatNode, key::AbstractString)
+    val = get(n, key, nothing)
+    val === nothing && throw(KeyError(key))
     val
 end
 
-function Base.haskey(n::FlatNode, key::AbstractString)
-    get(n, key, _MISSING_ATTR) !== _MISSING_ATTR
-end
+@inline Base.haskey(n::FlatNode, key::AbstractString) = get(n, key, nothing) !== nothing
 
 function Base.keys(n::FlatNode)
     r = _rec(n)
@@ -480,7 +477,16 @@ is_simple(n::FlatNode) = (r = _rec(n);
     r.kind === Element && r.attr_count == 0 && r.first_child != 0 &&
     (c = @inbounds n.store.recs[r.first_child]; c.next_sibling == 0 && (c.kind === Text || c.kind === CData)))
 
-is_simple_value(n::FlatNode) = is_simple(n) ? value(FlatNode(n.store, _rec(n).first_child)) : nothing
+# Hand-flattened `value(FlatNode(n.store, _rec(n).first_child))`: the extra call depth
+# pushed the SubString constructor past the inlining budget, and a constructor left as
+# `invoke` heap-materializes the returned view — 32 B per call (#105).
+@inline function is_simple_value(n::FlatNode)
+    is_simple(n) || return nothing
+    c = @inbounds n.store.recs[_rec(n).first_child]
+    c.value_offset < 0 && return nothing
+    raw = _fsub(n.store, c.value_offset, abs(c.value_len))
+    c.value_len < 0 ? unescape(raw) : raw
+end
 
 function simple_value(n::FlatNode)
     is_simple(n) || error("`simple_value` requires a simple node: an Element with no attributes and exactly one Text or CData child. See `is_simple`.")

--- a/src/lazynode.jl
+++ b/src/lazynode.jl
@@ -66,7 +66,10 @@ function tag(n::LazyNode)
     nothing
 end
 
-function value(n::LazyNode)
+# @inline: the `Union{Nothing, SubString{String}}` return only stays box-free when the
+# caller can union-split it — across a non-inlined boundary it costs 32 B per call (#105).
+# Same reason on the other union-returning accessors below and in cursor.jl/flatnode.jl.
+@inline function value(n::LazyNode)
     nt = n.nodetype
     if nt === Text
         return _decode(n.token, n.data)
@@ -95,12 +98,6 @@ function value(n::LazyNode)
 end
 
 #-----------------------------------------------------------------------------# attributes
-# Promote a `String` returned from `unescape` to a SubString so the homogeneous
-# `Attributes{SubString{String}}` parameterization works. The String was already
-# allocated for entity decoding; the SubString wrapper is just a view on top.
-@inline _as_substring(s::SubString{String}) = s
-@inline _as_substring(s::String) = SubString(s, 1, lastindex(s))
-
 function attributes(n::LazyNode)
     n.nodetype in (Element, Declaration) || return nothing
     iter = _lazy_tokenizer(n)
@@ -111,7 +108,7 @@ function attributes(n::LazyNode)
         name = raw(tok, n.data)
         result = iterate(iter)
         result === nothing && break
-        push!(attrs, name => _as_substring(_decode_attr(result[1], n.data)))
+        push!(attrs, name => _decode_attr(result[1], n.data))
     end
     isempty(attrs) ? nothing : Attributes(attrs)
 end
@@ -124,7 +121,7 @@ once — no `Attributes` allocation — so this is the recommended way to read a
 attribute from a `LazyNode`. Use [`eachattribute`](@ref) to stream all attribute pairs
 without allocating, or [`attributes`](@ref) for the materialized dict.
 """
-function Base.get(n::LazyNode, key::AbstractString, default)
+@inline function Base.get(n::LazyNode, key::AbstractString, default)
     n.nodetype in (Element, Declaration) || return default
     iter = _lazy_tokenizer(n)
     iterate(iter)  # skip OPEN_TAG or XML_DECL_OPEN
@@ -142,48 +139,46 @@ function Base.get(n::LazyNode, key::AbstractString, default)
 end
 
 #-----------------------------------------------------------------------------# eachattribute
-mutable struct LazyAttrIterator{I}
+# Immutable on purpose: the wrapped tokenizer carries all iteration state, so the wrapper
+# itself never mutates — which lets the whole iterator (tokenizer included) stay
+# stack-allocated when a `for` loop inlines it (#105). The standard iteration contract
+# applies: `iterate` must not be called again after it has returned `nothing`.
+struct LazyAttrIterator{I}
     iter::I
-    done::Bool
+    active::Bool
 end
 
 Base.IteratorSize(::Type{<:LazyAttrIterator}) = Base.SizeUnknown()
-Base.eltype(::Type{<:LazyAttrIterator}) = Pair{SubString{String}, Union{SubString{String}, String}}
+Base.eltype(::Type{<:LazyAttrIterator}) = Pair{SubString{String}, SubString{String}}
 
 """
     eachattribute(n::LazyNode)
 
-Lazy iterator yielding `name => value` pairs for the attributes of `n` (an `Element` or
-`Declaration`). Does not allocate an [`Attributes`](@ref) dict or intermediate vector;
-suitable for hot paths that only need to scan attributes.
+Lazy iterator yielding decoded `name => value` pairs for the attributes of `n` (an
+`Element` or `Declaration`). Allocation-free: no [`Attributes`](@ref) dict, no
+intermediate vector, and no per-pair boxing — suitable for hot paths that scan every
+attribute.
 
 For a single attribute by name, prefer `get(n, key, default)` — it short-circuits as soon
 as the match is found.
 """
-function eachattribute(n::LazyNode)
+@inline function eachattribute(n::LazyNode)
     iter = _lazy_tokenizer(n)
     is_attrs = n.nodetype === Element || n.nodetype === Declaration
     is_attrs && iterate(iter)  # skip OPEN_TAG / XML_DECL_OPEN
-    LazyAttrIterator{typeof(iter)}(iter, !is_attrs)
+    LazyAttrIterator{typeof(iter)}(iter, is_attrs)
 end
 
-function Base.iterate(it::LazyAttrIterator, _ = nothing)
-    it.done && return nothing
+@inline function Base.iterate(it::LazyAttrIterator, _ = nothing)
+    it.active || return nothing
     r = iterate(it.iter)
-    isnothing(r) && (it.done = true; return nothing)
+    isnothing(r) && return nothing
     tok = r[1]
-    if tok.kind !== TokenKinds.ATTR_NAME
-        it.done = true
-        return nothing
-    end
+    tok.kind === TokenKinds.ATTR_NAME || return nothing
     name = raw(tok, _src(it.iter))
     r = iterate(it.iter)
-    if isnothing(r)
-        it.done = true
-        return nothing
-    end
-    val = _decode_attr(r[1], _src(it.iter))
-    ((name => val), nothing)
+    isnothing(r) && return nothing
+    ((name => _decode_attr(r[1], _src(it.iter))), nothing)
 end
 
 #-----------------------------------------------------------------------------# foreach_attr
@@ -191,14 +186,14 @@ end
     foreach_attr(f, n::LazyNode)
 
 Call `f(name_token, value_token)` for each attribute of `n` (an `Element` or
-`Declaration`), where both arguments are `Token` values. Avoids the
-`Union{Nothing, T}` iteration protocol and its associated boxing, making this
-suitable for zero-allocation hot paths.
+`Declaration`), where both arguments are raw `Token` values.
 
-Recover attribute text with `XML.XMLTokenizer.raw(tok, n.data)` and decode
-attribute values with `XML.XMLTokenizer.attr_value(tok, n.data)`.
-
-For decoded `name => value` pairs, use [`eachattribute`](@ref) instead.
+To read attributes as decoded `name => value` pairs, use [`eachattribute`](@ref) — it is
+equally allocation-free. The token layer only makes sense for consumers that need byte
+offsets or the verbatim source: `XML.XMLTokenizer.attr_value(tok, n.data)` strips the
+surrounding quotes but performs **no** character-reference resolution and **no** XML 1.0
+§3.3.3 white-space normalization, so its output differs from the decoded accessors
+whenever an attribute carries references or literal tab/newline/CR.
 """
 function foreach_attr(f, n::LazyNode{String})
     n.nodetype in (Element, Declaration) || return
@@ -215,15 +210,13 @@ function foreach_attr(f, n::LazyNode{String})
     end
 end
 
-function Base.getindex(n::LazyNode, key::AbstractString)
-    val = get(n, key, _MISSING_ATTR)
-    val === _MISSING_ATTR && throw(KeyError(key))
+@inline function Base.getindex(n::LazyNode, key::AbstractString)
+    val = get(n, key, nothing)
+    val === nothing && throw(KeyError(key))
     val
 end
 
-function Base.haskey(n::LazyNode, key::AbstractString)
-    get(n, key, _MISSING_ATTR) !== _MISSING_ATTR
-end
+@inline Base.haskey(n::LazyNode, key::AbstractString) = get(n, key, nothing) !== nothing
 
 function Base.keys(n::LazyNode)
     n.nodetype in (Element, Declaration) || return ()
@@ -555,19 +548,18 @@ function is_simple(n::LazyNode)
     length(ch) == 1 && ch[1].nodetype in (Text, CData)
 end
 
-function simple_value(n::LazyNode)
-    n.nodetype === Element || error("`simple_value` is only defined for simple nodes.")
-    attrs = attributes(n)
-    (!isnothing(attrs) && !isempty(attrs)) && error("`simple_value` is only defined for simple nodes.")
-    ch = children(n)
-    length(ch) == 1 && ch[1].nodetype in (Text, CData) || error("`simple_value` is only defined for simple nodes.")
-    value(ch[1])
+# Delegates to the single-pass token walk of `is_simple_value` — materializing
+# `attributes` + `children` just to validate simplicity costs ~10× the walk (#105).
+@inline function simple_value(n::LazyNode)
+    v = is_simple_value(n)
+    v === nothing && error("`simple_value` is only defined for simple nodes.")
+    v
 end
 
 # Single-pass combined predicate+accessor: returns the simple text/CData value, or
 # `nothing` if `n` is not a simple element. Avoids the double tokenization of
 # `is_simple(n) ? simple_value(n) : ...`.
-function is_simple_value(n::LazyNode)
+@inline function is_simple_value(n::LazyNode)
     n.nodetype === Element || return nothing
     iter = _lazy_tokenizer(n)
     iterate(iter)  # skip OPEN_TAG

--- a/src/node.jl
+++ b/src/node.jl
@@ -191,10 +191,11 @@ is_simple(o::Node) = o.nodetype === Element &&
     o.children[1].nodetype in (Text, CData)
 
 """
-    simple_value(node) -> String
+    simple_value(node) -> Union{String, SubString{String}}
 
-Return the textual content of a simple element (see [`is_simple`](@ref)). Errors if
-`node` is not simple.
+Return the textual content of a simple element (see [`is_simple`](@ref)): a `String` on
+`Node`, a zero-copy `SubString{String}` on the other readers. Errors if `node` is not
+simple.
 """
 simple_value(o::Node) = is_simple(o) ? o.children[1].value :
     error("`simple_value` is only defined for simple nodes.")

--- a/src/node.jl
+++ b/src/node.jl
@@ -430,17 +430,16 @@ function Base.get(o::Node, key::AbstractString, default)
     default
 end
 
-const _MISSING_ATTR = gensym(:missing_attr)
-
-function Base.getindex(o::Node, key::AbstractString)
-    val = get(o, key, _MISSING_ATTR)
-    val === _MISSING_ATTR && throw(KeyError(key))
+# Missing keys are signalled by `nothing` (attribute values are always strings, never
+# `nothing`), not by a `Symbol` sentinel: a non-singleton default forces a union the
+# compiler cannot split away, heap-boxing the returned value at every call (#105).
+@inline function Base.getindex(o::Node, key::AbstractString)
+    val = get(o, key, nothing)
+    val === nothing && throw(KeyError(key))
     val
 end
 
-function Base.haskey(o::Node, key::AbstractString)
-    get(o, key, _MISSING_ATTR) !== _MISSING_ATTR
-end
+@inline Base.haskey(o::Node, key::AbstractString) = get(o, key, nothing) !== nothing
 
 Base.keys(o::Node) = isnothing(o.attributes) ? () : first.(o.attributes)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3896,6 +3896,7 @@ end
 @testset "test_libxml2_testcases" begin include("test_libxml2_testcases.jl") end
 @testset "test_w3c" begin include("test_w3c.jl") end
 @testset "test_tokenizer" begin include("test_tokenizer.jl") end
+@testset "test_allocations" begin include("test_allocations.jl") end
 @testset "test_cursor" begin include("test_cursor.jl") end
 @testset "test_flatnode" begin include("test_flatnode.jl") end
 @testset "test_node_identity" begin include("test_node_identity.jl") end

--- a/test/test_allocations.jl
+++ b/test/test_allocations.jl
@@ -1,0 +1,132 @@
+# Decoded read surface — allocation guards. A union-typed return that survives a
+# non-inlined call boundary heap-boxes every call (32 B); in per-cell hot loops
+# (spreadsheet-style attribute sweeps) that box dominates the accessor's real work
+# (#98, #104, #105). Every guard measures inside a function barrier — the call, not the
+# caller's dynamically-typed scope — and consumes the value in place, so a boxed return
+# cannot hide behind the measuring boundary.
+
+using Test, XML
+using XML: unescape
+
+# The value-correctness checks always run (they double as compile warm-up for each
+# barrier); the `== 0` assertions are skipped under coverage, whose counters allocate
+# inside the measured call (same gate as the `_normalize_attr_ws` guard in runtests.jl).
+const _NO_COVERAGE = Base.JLOptions().code_coverage == 0
+
+_use(v) = v === nothing ? 0 : ncodeunits(v)
+
+measure_get(x)       = @allocated _use(get(x, "r", nothing))
+measure_index(x)     = @allocated _use(x["r"])
+measure_haskey(x)    = @allocated haskey(x, "r")
+measure_tag(x)       = @allocated _use(tag(x))
+measure_value(x)     = @allocated _use(value(x))
+measure_simple(x)    = @allocated _use(simple_value(x))
+measure_is_simple(x) = @allocated _use(is_simple_value(x))
+function measure_eachattr(x)
+    @allocated begin
+        s = 0
+        for (k, v) in eachattribute(x)
+            s += ncodeunits(k) + ncodeunits(v)
+        end
+        s
+    end
+end
+
+@testset "Decoded read surface: allocation-free" begin
+    attr_xml   = """<c r="A1" s="3" t="str"/>"""
+    simple_xml = "<a>hello</a>"
+
+    lz = only(eachelement(parse(attr_xml, LazyNode)))
+    fl = only(eachelement(parse(attr_xml, FlatNode)))
+    nd = only(eachelement(parse(attr_xml, Node)))
+    cu = parse(Cursor, attr_xml); next!(cu)                 # positioned on <c>
+
+    slz = only(eachelement(parse(simple_xml, LazyNode)))
+    sfl = only(eachelement(parse(simple_xml, FlatNode)))
+    snd = only(eachelement(parse(simple_xml, Node)))
+    scu = parse(Cursor, simple_xml); next!(scu)             # positioned on <a>
+
+    tlz = only(children(slz))
+    tfl = only(children(sfl))
+    tnd = only(children(snd))
+    tcu = parse(Cursor, simple_xml); next!(tcu); next!(tcu) # positioned on the Text node
+
+    @testset "the shared decode root is type-stable" begin
+        @test only(Base.return_types(unescape, (SubString{String},))) === SubString{String}
+    end
+
+    @testset "guarded fixtures read correctly" begin
+        for x in (lz, fl, cu, nd)
+            @test get(x, "r", nothing) == "A1"
+            @test get(x, "nope", nothing) === nothing
+            @test x["r"] == "A1"
+            @test_throws KeyError x["nope"]
+            @test haskey(x, "r") && !haskey(x, "nope")
+            @test tag(x) == "c"
+        end
+        @test collect(eachattribute(lz)) == ["r" => "A1", "s" => "3", "t" => "str"]
+        for x in (tlz, tfl, tcu, tnd)
+            @test value(x) == "hello"
+        end
+        for x in (slz, sfl, snd)
+            @test simple_value(x) == "hello"
+        end
+        for x in (slz, sfl, scu, snd)
+            @test is_simple_value(x) == "hello"
+        end
+    end
+
+    # compile every barrier specialization before measuring
+    for x in (lz, fl, cu, nd)
+        measure_get(x); measure_index(x); measure_haskey(x); measure_tag(x)
+    end
+    measure_eachattr(lz)
+    foreach(measure_value, (tlz, tfl, tcu, tnd))
+    foreach(measure_simple, (slz, sfl, snd))
+    foreach(measure_is_simple, (slz, sfl, scu, snd))
+
+    if _NO_COVERAGE
+        @testset "by-key attribute reads" begin
+            @test measure_get(lz) == 0
+            @test measure_get(fl) == 0
+            @test measure_get(cu) == 0
+            @test measure_get(nd) == 0
+            @test measure_index(lz) == 0
+            @test measure_index(fl) == 0
+            @test measure_index(cu) == 0
+            @test measure_index(nd) == 0
+            @test measure_haskey(lz) == 0
+            @test measure_haskey(fl) == 0
+            @test measure_haskey(cu) == 0
+            @test measure_haskey(nd) == 0
+        end
+
+        @testset "tag" begin
+            @test measure_tag(lz) == 0
+            @test measure_tag(fl) == 0
+            @test measure_tag(cu) == 0
+            @test measure_tag(nd) == 0
+        end
+
+        @testset "value on a Text node" begin
+            @test measure_value(tlz) == 0
+            @test measure_value(tfl) == 0
+            @test measure_value(tcu) == 0
+            @test measure_value(tnd) == 0
+        end
+
+        @testset "simple_value / is_simple_value" begin
+            @test measure_simple(slz) == 0
+            @test measure_simple(sfl) == 0
+            @test measure_simple(snd) == 0
+            @test measure_is_simple(slz) == 0
+            @test measure_is_simple(sfl) == 0
+            @test measure_is_simple(scu) == 0
+            @test measure_is_simple(snd) == 0
+        end
+
+        @testset "eachattribute streams without allocating" begin
+            @test measure_eachattr(lz) == 0
+        end
+    end
+end


### PR DESCRIPTION
Closes #105. Every non-zero cell of the issue's measurement table now reads 0 B — `n["key"]`/`get`/`haskey`, `value`, `simple_value`/`is_simple_value` and `eachattribute` across `LazyNode`, `FlatNode` and `Cursor` — and the whole `eachattribute` iteration measures 0 B iterator included, not just per pair.

The chain, root first:

- `unescape(::SubString{String})` now returns `SubString{String}` concretely (the rare rewrite path wraps its fresh `String` back into a view). This was the shared root: every reader's decode funnel calls it on the hot path.
- The `_MISSING_ATTR::Symbol` sentinel is gone: `getindex`/`haskey` signal a miss with `nothing` (an attribute value is never `nothing` — XML has no valueless attributes, and the decode funnels only produce strings), which the compiler union-splits where a non-singleton `Symbol` default used to force a box before this PR.
- The union-returning accessors are `@inline`, so callers split the `Union{Nothing, SubString{String}}` return instead of boxing it at a non-inlined call boundary.
- `simple_value(::LazyNode)` runs the single-pass token walk `is_simple_value` already used, instead of materializing `attributes` + `children` just to validate simplicity (320 B → 0).
- `LazyAttrIterator` is immutable with a concrete `Pair{SubString{String}, SubString{String}}` eltype, so the whole iterator (wrapped tokenizer included) stays stack-allocated once the loop inlines.
- One `FlatNode` subtlety: `is_simple_value` is hand-flattened — at its original call depth the `SubString` constructor fell past the inlining budget, and a constructor left as `invoke` heap-materializes the returned view even though inference is fully concrete.

This also carries the #104 documentation fix: `foreach_attr`'s docstring no longer recommends `XML.XMLTokenizer.raw`/`attr_value`; it points to `eachattribute` (decoded, equally allocation-free) and spells out the raw-layer caveat — quote-stripping only, no character-reference resolution, no §3.3.3 white-space normalization. Nothing is removed: the token layer keeps working exactly as before.

The documentation figures are refreshed in the same PR — Tables 1–4 of PERFORMANCE-v0.4.md and the README access-pattern table, re-measured on the same corpus and protocols: a full `Cursor` streaming pass drops from 53 ms / 17 MiB to 46 ms / 0 allocation, `FlatNode` value extraction from 9.3 to 6.6 ms, and every control cell (EzXML, LightXML, the lexer, `Node`'s field reads) is stable within the documented GC lottery. The README cross-library Benchmarks table is untouched: parse/write/collect-tags exercise none of the changed paths.

Semantics are unchanged — `KeyError`/default contracts, entity decoding and §3.3.3 normalization apply as before, and the full suite passes untouched. New function-barrier allocation guards (`test/test_allocations.jl`) pin every accessor at zero; the value-correctness checks always run, while the `== 0` assertions are skipped under coverage, whose counters allocate inside the measured call.