### PR TITLE
Eliminate per-element vector churn in the Node build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exact-size vector — or `nothing`, allocation-free, when the element has none. On the
   14 MB benchmark corpus this removes ~380 K allocations and ~22 MiB of garbage per build
   (−14 % total build time, −5.7 ms GC-free work), and the finished tree no longer retains
-  `push!`-growth overcapacity in its children vectors (#107).
+  `push!`-growth overcapacity in its children vectors — the retained tree shrinks from
+  80.0 to 71.6 MiB and full walks of it run ~1.4× faster (#107).
 
 ## [0.4.4] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The `Node` build no longer allocates per-element vectors**: children and attributes
   accumulate on two parse-wide scratch stacks and each closing tag slices out one
   exact-size vector — or `nothing`, allocation-free, when the element has none. On the
-  14 MB benchmark corpus this removes ~380 K allocations and ~22 MiB of garbage per build
-  (−14 % total build time, −5.7 ms GC-free work), and the finished tree no longer retains
-  `push!`-growth overcapacity in its children vectors — the retained tree shrinks from
-  80.0 to 71.6 MiB and full walks of it run ~1.4× faster (#107).
+  14 MB benchmark corpus this removes ~380 K allocations and ~22 MiB of garbage per build;
+  the time saved scales with ambient GC pressure (−3 % to −14 % of build time across
+  measured regimes — the win comes from skipped collections, not raw CPU). The finished
+  tree no longer retains `push!`-growth overcapacity in its children vectors: the retained
+  tree shrinks from 80.0 to 71.6 MiB and full walks of it run ~1.4× faster (#107).
 
 ## [0.4.4] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tree no longer retains `push!`-growth overcapacity in its children vectors: the retained
   tree shrinks from 80.0 to 71.6 MiB and full walks of it run ~1.4× faster (#107).
 
+- **One measurement protocol across the performance docs**: every timing in
+  PERFORMANCE-v0.4.md and the README access-pattern table is now a BenchmarkTools
+  `@benchmark` median — the per-reader table and the GC-tuning note were previously
+  measured by a custom median-of-N harness on a freshly collected heap, so their numbers
+  were not comparable with the BenchmarkTools tables beside them.
+  `benchmarks/flatnode_bench.jl` is rewritten accordingly (its `--gc-only` mode
+  reproduces the GC-tuning pair) and the affected cells re-measured (#107).
+
 ## [0.4.4] - 2026-07-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **One measurement protocol across the performance docs**: every timing in
   PERFORMANCE-v0.4.md and the README access-pattern table is now a BenchmarkTools
   `@benchmark` median — the per-reader table and the GC-tuning note were previously
-  measured by a custom median-of-N harness on a freshly collected heap, so their numbers
+  measured by a custom median-of-N script on a freshly collected heap, so their numbers
   were not comparable with the BenchmarkTools tables beside them.
   `benchmarks/flatnode_bench.jl` is rewritten accordingly (its `--gc-only` mode
   reproduces the GC-tuning pair) and the affected cells re-measured (#107).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   accumulate on two parse-wide scratch stacks and each closing tag slices out one
   exact-size vector — or `nothing`, allocation-free, when the element has none. On the
   14 MB benchmark corpus this removes ~380 K allocations and ~22 MiB of garbage per build;
-  the time saved scales with ambient GC pressure — a standalone parse gains ~2-3 ms, rising
-  to ~14 ms per parse when the heap holds a large live set, since every skipped collection
-  stops re-marking whatever else the application keeps in memory. The finished
+  the time saved depends on what else the heap holds — a standalone parse gains ~2-3 ms,
+  rising to ~14 ms per parse when earlier documents are kept in memory, since every skipped
+  collection stops re-marking whatever else the application holds. The finished
   tree no longer retains `push!`-growth overcapacity in its children vectors: the retained
   tree shrinks from 80.0 to 71.6 MiB and full walks of it run ~1.4× faster (#107).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the benchmark corpus, at no cost to computation (mark threads only run while compute is
   paused). Measured guidance for applications that hold big trees.
 
+### Changed
+
+- **The `Node` build no longer allocates per-element vectors**: children and attributes
+  accumulate on two parse-wide scratch stacks and each closing tag slices out one
+  exact-size vector — or `nothing`, allocation-free, when the element has none. On the
+  14 MB benchmark corpus this removes ~380 K allocations and ~22 MiB of garbage per build
+  (−14 % total build time, −5.7 ms GC-free work), and the finished tree no longer retains
+  `push!`-growth overcapacity in its children vectors (#107).
+
 ## [0.4.4] - 2026-07-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   accumulate on two parse-wide scratch stacks and each closing tag slices out one
   exact-size vector — or `nothing`, allocation-free, when the element has none. On the
   14 MB benchmark corpus this removes ~380 K allocations and ~22 MiB of garbage per build;
-  the time saved scales with ambient GC pressure (−3 % to −14 % of build time across
-  measured regimes — the win comes from skipped collections, not raw CPU). The finished
+  the time saved scales with ambient GC pressure — a standalone parse gains ~2-3 ms, rising
+  to ~14 ms per parse when the heap holds a large live set, since every skipped collection
+  stops re-marking whatever else the application keeps in memory. The finished
   tree no longer retains `push!`-growth overcapacity in its children vectors: the retained
   tree shrinks from 80.0 to 71.6 MiB and full walks of it run ~1.4× faster (#107).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The `Node` build no longer allocates per-element vectors**: children and attributes
   accumulate on two parse-wide scratch stacks and each closing tag slices out one
   exact-size vector — or `nothing`, allocation-free, when the element has none. On the
-  14 MB benchmark corpus this removes ~380 K allocations and ~22 MiB of garbage per build;
-  the time saved depends on what else the heap holds — a standalone parse gains ~2-3 ms,
-  rising to ~14 ms per parse when earlier documents are kept in memory, since every skipped
-  collection stops re-marking whatever else the application holds. The finished
+  14 MB benchmark corpus this removes ~380 K allocations (−13 %) and ~22 MiB of garbage per
+  build, for a median build time of −7.5 % (BenchmarkTools) — and the time win grows with
+  how much garbage the collector has to manage. The finished
   tree no longer retains `push!`-growth overcapacity in its children vectors: the retained
   tree shrinks from 80.0 to 71.6 MiB and full walks of it run ~1.4× faster (#107).
 

--- a/PERFORMANCE-v0.4.md
+++ b/PERFORMANCE-v0.4.md
@@ -42,7 +42,7 @@ untouched; EzXML's `StreamReader` is libxml2's reader, paying FFI per event:
 | Stream | time (incl. GC) | memory |
 |---|--:|--:|
 | **XML.jl `Cursor`** | **46 ms** | **0.0 MiB** |
-| EzXML `StreamReader` | 68 ms (GC 1.3) | 36 MiB |
+| EzXML `StreamReader` | 68 ms (GC 0.8) | 36 MiB |
 
 _Table 1 — streaming: events only, no tree built._[^profile]
 
@@ -71,10 +71,10 @@ libxml2 wins the build; XML.jl materialises an 882 K-node Julia tree, EzXML a le
 
 | Full DOM extract | time (incl. GC) | memory |
 |---|--:|--:|
-| EzXML (libxml2) | **63 ms** | **54 MiB** |
-| LightXML (elements only) | 63 ms (GC 1.5) | 57 MiB |
-| XML.jl (`SubString`, zero-copy) | 117 ms (GC 41) | 120 MiB |
-| XML.jl (`String`) | 143 ms (GC 45) | 122 MiB |
+| EzXML (libxml2) | **60 ms** | **54 MiB** |
+| LightXML (elements only) | 62 ms (GC 1.3) | 57 MiB |
+| XML.jl (`SubString`, zero-copy) | 93 ms (GC 20) | 95 MiB |
+| XML.jl (`String`) | 103 ms (GC 24) | 100 MiB |
 | XML.jl **v0.3.9** (previous release) | 530 ms | 1422 MiB |
 
 _Table 2 — full-DOM extraction (parse + pull every tag/text), cross-library._[^profile]
@@ -84,13 +84,13 @@ _Table 2 — full-DOM extraction (parse + pull every tag/text), cross-library._[
 | Stage | time (incl. GC) | allocated |
 |---|--:|--:|
 | read file (I/O) | 0.6 ms | — |
-| **lex — the DFA** | **36.5 ms** | **0 B** |
-| build the tree — the VPA | ~76 ms (GC 28) | 122 MiB |
-| traverse a built tree | 6.4 ms | 0 B |
+| **lex — the DFA** | **37.2 ms** | **0 B** |
+| build the tree — the VPA | ~62 ms (GC 23) | 100 MiB |
+| traverse a built tree | 4.0 ms | 0 B |
 
 _Table 3 — the XML.jl pipeline, decomposed (`String` variant)._[^profile]
 
-The lexer is allocation-free; **the whole libxml2 gap is *materialising* the native tree, not scanning it** — and the GC column shows where that cost lives: the allocation-free lex cannot trigger a collection, so every garbage-collector pause inside a parse lands in the build, the toll of 882 K fresh objects. The GC share is also the *volatile* part of these numbers: it moves with the heap state a session inherits (this page has measured the `String` extraction's total anywhere from 115 to 143 ms), while the GC-free remainder reproduces within a few percent.
+The lexer is allocation-free; **the whole libxml2 gap is *materialising* the native tree, not scanning it** — and the GC column shows where that cost lives: the allocation-free lex cannot trigger a collection, so every garbage-collector pause inside a parse lands in the build, the toll of 882 K fresh objects. The GC share is also the *volatile* part of these numbers: it moves with the heap state a session inherits (before the scratch-stack build landed, this page measured the `String` extraction's total anywhere from 115 to 143 ms across sessions), while the GC-free remainder reproduces within a few percent.
 
 ### `FlatNode` (v0.4.2, experimental)
 
@@ -108,13 +108,13 @@ Measured on the same XMark document:
 
 | Full DOM, per reader | build (incl. GC) | walk every node | extract all values | DOM size in memory |
 |---|--:|--:|--:|--:|
-| **`FlatNode`** | **52.1 ms** | **2.94 ms** | 6.6 ms | **54.9 MiB** |
-| `Node` | 93.4 ms (GC 15.4) | 5.2 ms | **5.4 ms** | 80.0 MiB |
-| EzXML (libxml2) | 37.8 ms | — | — | — |
+| **`FlatNode`** | **53.4 ms** | **2.91 ms** | 6.5 ms | **54.9 MiB** |
+| `Node` | 90.0 ms (GC 16.4) | 5.1 ms | **5.1 ms** | 71.6 MiB |
+| EzXML (libxml2) | 37.7 ms | — | — | — |
 
 _Table 4 — per-reader full-DOM comparison (median run of 7, default settings); *build* is the whole `parse` call, and *DOM size* is the **retained** live tree (`Base.summarysize`), not allocations._[^flatbench]
 
-Build allocations: 73.7 MiB (`FlatNode`) vs 122.3 MiB (`Node`), and the libxml2 *build* gap narrows from ~2.5× to ~1.4×. Note the GC cells: on a freshly collected heap, `FlatNode`'s build triggers *no* collection at all — a handful of arrays instead of 882 K objects — where `Node`'s pays 15 ms of GC inside the same corpus. Beyond the cheaper build, access itself is faster on `FlatNode`: full walks run ~1.8× faster (the contiguous scan), and `parent`/`depth` are O(1) index hops where `Node` must search down from the root. The one pattern where `Node` keeps an edge is pure value extraction on an already-built tree (5.4 vs 6.6 ms): direct field reads still beat computed `SubString` views, though only by ~20 % now that the decoded accessors return their views unboxed.
+Build allocations: 73.7 MiB (`FlatNode`) vs 99.8 MiB (`Node` — down from 122.3 MiB before the scratch-stack build), and the libxml2 *build* gap narrows from ~2.5× to ~1.4×. Note the GC cells: on a freshly collected heap, `FlatNode`'s build triggers *no* collection at all — a handful of arrays instead of 882 K objects — where `Node`'s pays ~16 ms of GC inside the same corpus. Beyond the cheaper build, access itself is faster on `FlatNode`: full walks run ~1.8× faster (the contiguous scan), and `parent`/`depth` are O(1) index hops where `Node` must search down from the root. The one pattern where `Node` keeps an edge is pure value extraction on an already-built tree (5.1 vs 6.5 ms): direct field reads still beat computed `SubString` views by ~30 % — exact-size children vectors sharpened `Node`'s own cache locality.
 
 ### Choosing
 
@@ -127,12 +127,12 @@ Stream / low-memory / read-only full-DOM / repeated traversal → **XML.jl**; a 
 > **GC tuning for tree-holding applications.** A single-threaded Julia process defaults to
 > *one* GC thread; `--gcthreads=4` (the performance-core count here) parallelizes the mark
 > phase, cutting a full collection with this corpus's 882 K-node `Node` tree live from
-> ~56 ms to ~21 ms — and the build's GC share shrinks accordingly (measured 2026-07-31,
-> same machine and Julia as above, AC ≡ battery). Mark threads sleep outside collections
+> ~49 ms to ~18 ms — and the build's GC share shrinks accordingly (measured 2026-08-01,
+> same machine and Julia as above). Mark threads sleep outside collections
 > and run only while compute is paused anyway, so the setting takes nothing from
 > computation. It trims GC pauses, not the materialization floor: the build's GC-free work
 > is unchanged.
 
-[^profile]: Tables 1–3: measured 2026-07-30 (the `v0.3.9` row: 2026-06-28), Apple M5 (single-threaded), Julia 1.12.6; EzXML 1.2.3 / LightXML 0.9.3 (libxml2 2.15.3). Each time is the median sample's total, its *(GC x)* tail that same sample's garbage-collection share — omitted when below 0.05 ms; the total minus it is the GC-free work, the reproducible part of the number. Source: [`benchmarks/profile.jl`](benchmarks/profile.jl).
+[^profile]: Tables 1–3: measured 2026-08-01 (the `v0.3.9` row: 2026-06-28), Apple M5 (single-threaded), Julia 1.12.6; EzXML 1.2.3 / LightXML 0.9.3 (libxml2 2.15.3). Each time is the median sample's total, its *(GC x)* tail that same sample's garbage-collection share — omitted when below 0.05 ms; the total minus it is the GC-free work, the reproducible part of the number. Source: [`benchmarks/profile.jl`](benchmarks/profile.jl).
 
-[^flatbench]: Table 4: measured 2026-07-30, same machine and Julia; source [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl) — each cell is the median run of 7, every run starting from a freshly collected heap, so its *(GC x)* tail is that run's own allocation cost, not inherited debt.
+[^flatbench]: Table 4: measured 2026-08-01, same machine and Julia; source [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl) — each cell is the median run of 7, every run starting from a freshly collected heap, so its *(GC x)* tail is that run's own allocation cost, not inherited debt.

--- a/PERFORMANCE-v0.4.md
+++ b/PERFORMANCE-v0.4.md
@@ -35,20 +35,14 @@ The well-formedness level is a type parameter (`Val{W}`), so `:strict`/`:structu
 Performance isn't one number — it splits by *what you do with the document*. 14 MB [XMark](https://projects.cwi.nl/xmark/) file (XML.jl and EzXML walk the same ~882 K nodes); **lower is better.**
 
 > [!NOTE]
-> **How to read the timings — what memory holds when a number is taken.** In every
-> protocol the code is compiled and warm; what differs is the memory state a run starts
-> from, and therefore how much garbage-collection work it triggers. The *(GC x)* share of
-> a number is only comparable between numbers taken from the same starting state:
->
-> - **Back-to-back samples** (Tables 1–3): each sample inherits the garbage the previous
->   one left behind — the *(GC x)* tail is what a working session actually pays.
-> - **Freshly collected heap** (Table 4): every run starts right after a full collection —
->   the *(GC x)* tail is that run's own allocation cost, with no inherited debt.
-> - **With a built tree held in memory** (the GC-tuning note below): what each collection
->   costs while a tree stays live — the cost a skipped collection avoids re-paying.
->
-> Across all three, the GC share is the volatile part; the GC-free remainder reproduces
-> within a few percent and is the number to compare across sessions or versions.
+> **How to read the timings.** Every timing on this page is a BenchmarkTools
+> `@benchmark` measurement at default parameters: samples run back-to-back from a warm,
+> compiled state, and the quoted number is the median sample, with the median
+> garbage-collection share as its *(GC x)* tail (omitted below 0.05 ms). The GC share
+> is the volatile part of a Julia timing — it moves with the heap state a session
+> inherits — while the number minus its GC share reproduces within a few percent and is
+> the one to compare across sessions or versions. Allocation totals and retained sizes
+> are deterministic facts, identical under any protocol.
 
 ### Stream — events, no tree
 
@@ -95,18 +89,18 @@ libxml2 wins the build; XML.jl materialises an 882 K-node Julia tree, EzXML a le
 
 _Table 2 — full-DOM extraction (parse + pull every tag/text), cross-library._[^profile]
 
-**Decomposed** (XML.jl, the `String` variant — subtract each row's GC share and the stages sum to the Table 2 row's own GC-free time, within noise):
+**Decomposed** (XML.jl, the `String` variant — every row a direct measurement; the lex is the first stage *inside* the parse row, so their difference prices the tree build, and parse + traverse reproduces the Table 2 row within noise):
 
 | Stage | time (incl. GC) | allocated |
 |---|--:|--:|
 | read file (I/O) | 0.6 ms | — |
 | **lex — the DFA** | **37.2 ms** | **0 B** |
-| build the tree — the VPA | ~62 ms (GC 23) | 100 MiB |
+| parse → DOM (lex + build the tree, the VPA) | 99.2 ms (GC 23) | 100 MiB |
 | traverse a built tree | 4.0 ms | 0 B |
 
 _Table 3 — the XML.jl pipeline, decomposed (`String` variant)._[^profile]
 
-The lexer is allocation-free; **the whole libxml2 gap is *materialising* the native tree, not scanning it** — and the GC column shows where that cost lives: the allocation-free lex cannot trigger a collection, so every garbage-collector pause inside a parse lands in the build, the toll of 882 K fresh objects. The GC share is also the *volatile* part of these numbers: it moves with the heap state a session inherits (before the scratch-stack build landed, this page measured the `String` extraction's total anywhere from 115 to 143 ms across sessions), while the GC-free remainder reproduces within a few percent.
+The lexer is allocation-free; **the whole libxml2 gap is *materialising* the native tree, not scanning it** — and the GC column shows where that cost lives: the allocation-free lex cannot trigger a collection, so every garbage-collector pause inside a parse lands in the build, the toll of 882 K fresh objects.
 
 ### `FlatNode` (v0.4.2, experimental)
 
@@ -124,17 +118,17 @@ Measured on the same XMark document:
 
 | Full DOM, per reader | build (incl. GC) | walk every node | extract all values | DOM size in memory |
 |---|--:|--:|--:|--:|
-| **`FlatNode`** | **53.4 ms** | **2.91 ms** | 6.5 ms | **54.9 MiB** |
-| `Node` | 90.0 ms (GC 16.4) | 5.1 ms | **5.1 ms** | 71.6 MiB |
-| EzXML (libxml2) | 37.7 ms | — | — | — |
+| **`FlatNode`** | **53.2 ms (GC 0.4)** | **2.97 ms** | 6.6 ms | **54.9 MiB** |
+| `Node` | 99.8 ms (GC 24) | 3.27 ms | **3.6 ms** | 71.6 MiB |
+| EzXML (libxml2) | 47.5 ms | — | — | — |
 
-_Table 4 — per-reader full-DOM comparison (median run of 7, default settings); *build* is the whole `parse` call, and *DOM size* is the **retained** live tree (`Base.summarysize`), not allocations._[^flatbench]
+_Table 4 — per-reader full-DOM comparison; *build* is the whole `parse` call, and *DOM size* is the **retained** live tree (`Base.summarysize`), not allocations._[^flatbench]
 
-Build allocations: 73.7 MiB (`FlatNode`) vs 99.8 MiB (`Node` — down from 122.3 MiB before the scratch-stack build), and the libxml2 *build* gap narrows from ~2.5× to ~1.4×. Note the GC cells: on a freshly collected heap, `FlatNode`'s build triggers *no* collection at all — a handful of arrays instead of 882 K objects — where `Node`'s pays ~16 ms of GC inside the same corpus. Beyond the cheaper build, access itself is faster on `FlatNode`: full walks run ~1.8× faster (the contiguous scan), and `parent`/`depth` are O(1) index hops where `Node` must search down from the root. The one pattern where `Node` keeps an edge is pure value extraction on an already-built tree (5.1 vs 6.5 ms): direct field reads still beat computed `SubString` views by ~30 % — exact-size children vectors sharpened `Node`'s own cache locality.
+Build allocations: 42.2 MiB (`FlatNode`) vs 99.8 MiB (`Node` — down from 122.3 MiB before the scratch-stack build), and the libxml2 *build* gap is ~1.1× to `FlatNode`, ~2.1× to `Node`. The GC cells say why: `FlatNode`'s build allocates a handful of arrays instead of 882 K objects, so its median GC share is ~0.4 ms where `Node`'s is ~24 ms. Access on the finished stores is closer than the build: whole-tree walks are near-parity (2.97 vs 3.27 ms — exact-size children vectors sharpened `Node`'s cache locality), `parent`/`depth` stay O(1) index hops on `FlatNode` where `Node` must search down from the root, and pure value extraction on an already-built tree is the pattern where `Node`'s direct field reads win outright (3.6 vs 6.6 ms, ~1.8× — a computed `SubString` view per value is the flat store's toll).
 
 ### Choosing
 
-Stream / low-memory / read-only full-DOM / repeated traversal → **XML.jl**; a one-shot build-and-extract is the one job where a libxml2 binder still builds ~1.4× faster (was ~2.5× before `FlatNode`) — either way, pure Julia, no C dependency. Against its own past, v0.4 is **~5× faster and ~12× leaner than 0.3.9** (which used ~1.4 GiB for this file) — see [`benchmarks/profile.jl`](benchmarks/profile.jl), [`benchmarks/profile_vs_039.jl`](benchmarks/profile_vs_039.jl), [`benchmarks/compare.jl`](benchmarks/compare.jl).
+Stream / low-memory / read-only full-DOM / repeated traversal → **XML.jl**; a one-shot build-and-extract is the one job where a libxml2 binder still builds faster — ~1.1× vs `FlatNode`, ~2.1× vs `Node` — either way, pure Julia, no C dependency. Against its own past, v0.4 is **~5× faster and ~12× leaner than 0.3.9** (which used ~1.4 GiB for this file) — see [`benchmarks/profile.jl`](benchmarks/profile.jl), [`benchmarks/profile_vs_039.jl`](benchmarks/profile_vs_039.jl), [`benchmarks/compare.jl`](benchmarks/compare.jl).
 
 > [!NOTE]
 > **`:strict`** adds a character-range scan over text (a second O(content) pass); the overhead scales with the document's *text share* — ~1.1× on the markup-heavy XMark corpus, up to ~20× on a pure-text document; `:lenient` / `:structural` are unaffected.
@@ -143,12 +137,13 @@ Stream / low-memory / read-only full-DOM / repeated traversal → **XML.jl**; a 
 > **GC tuning for tree-holding applications.** A single-threaded Julia process defaults to
 > *one* GC thread; `--gcthreads=4` (the performance-core count here) parallelizes the mark
 > phase, cutting a full collection with this corpus's 882 K-node `Node` tree live from
-> ~49 ms to ~18 ms — and the build's GC share shrinks accordingly (measured 2026-08-01,
-> same machine and Julia as above). Mark threads sleep outside collections
+> ~56 ms to ~20 ms (median `@benchmark GC.gc(true)` sample; the `--gc-only` mode of
+> [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl) reproduces the pair) —
+> and the build's GC share shrinks accordingly. Mark threads sleep outside collections
 > and run only while compute is paused anyway, so the setting takes nothing from
 > computation. It trims GC pauses, not the materialization floor: the build's GC-free work
 > is unchanged.
 
-[^profile]: Tables 1–3: measured 2026-08-01 (the `v0.3.9` row: 2026-06-28), Apple M5 (single-threaded), Julia 1.12.6; EzXML 1.2.3 / LightXML 0.9.3 (libxml2 2.15.3). Each time is the median sample's total, its *(GC x)* tail that same sample's garbage-collection share — omitted when below 0.05 ms; the total minus it is the GC-free work, the reproducible part of the number. Source: [`benchmarks/profile.jl`](benchmarks/profile.jl).
+[^profile]: Tables 1–3: measured 2026-08-01 (the `v0.3.9` row: 2026-06-28), Apple M5 (single-threaded), Julia 1.12.6; EzXML 1.2.3 / LightXML 0.9.3 (libxml2 2.15.3); BenchmarkTools at a 5 s budget per cell. Source: [`benchmarks/profile.jl`](benchmarks/profile.jl).
 
-[^flatbench]: Table 4: measured 2026-08-01, same machine and Julia; source [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl) — each cell is the median run of 7, every run starting from a freshly collected heap, so its *(GC x)* tail is that run's own allocation cost, not inherited debt.
+[^flatbench]: Table 4 (and the README access-pattern table): measured 2026-08-02, same machine, Julia and BenchmarkTools settings; source [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl).

--- a/PERFORMANCE-v0.4.md
+++ b/PERFORMANCE-v0.4.md
@@ -34,6 +34,21 @@ The well-formedness level is a type parameter (`Val{W}`), so `:strict`/`:structu
 
 Performance isn't one number — it splits by *what you do with the document*. 14 MB [XMark](https://projects.cwi.nl/xmark/) file (XML.jl and EzXML walk the same ~882 K nodes); **lower is better.**
 
+> [!NOTE]
+> **How to read the timings — three heap regimes.** A number's *(GC x)* share is only
+> comparable within its own regime:
+>
+> - **Continuous session** (Tables 1–3): BenchmarkTools samples run back-to-back, each
+>   inheriting the heap the previous one left — the *(GC x)* tail is what a working
+>   session actually pays.
+> - **Fresh heap per run** (Table 4): every run starts from a freshly collected heap, so
+>   its *(GC x)* tail is that run's own allocation cost, not inherited debt.
+> - **Live-set** (the GC-tuning note below): what each collection costs while a built tree
+>   is *held* in memory — the cost a skipped collection avoids re-paying.
+>
+> Across all three, the GC share is the volatile part; the GC-free remainder reproduces
+> within a few percent and is the number to compare across sessions or versions.
+
 ### Stream — events, no tree
 
 `Cursor` pulls in pure Julia — a full pass, decoded reads included, leaves the allocator

--- a/PERFORMANCE-v0.4.md
+++ b/PERFORMANCE-v0.4.md
@@ -35,16 +35,17 @@ The well-formedness level is a type parameter (`Val{W}`), so `:strict`/`:structu
 Performance isn't one number — it splits by *what you do with the document*. 14 MB [XMark](https://projects.cwi.nl/xmark/) file (XML.jl and EzXML walk the same ~882 K nodes); **lower is better.**
 
 > [!NOTE]
-> **How to read the timings — three heap regimes.** A number's *(GC x)* share is only
-> comparable within its own regime:
+> **How to read the timings — what memory holds when a number is taken.** In every
+> protocol the code is compiled and warm; what differs is the memory state a run starts
+> from, and therefore how much garbage-collection work it triggers. The *(GC x)* share of
+> a number is only comparable between numbers taken from the same starting state:
 >
-> - **Continuous session** (Tables 1–3): BenchmarkTools samples run back-to-back, each
->   inheriting the heap the previous one left — the *(GC x)* tail is what a working
->   session actually pays.
-> - **Fresh heap per run** (Table 4): every run starts from a freshly collected heap, so
->   its *(GC x)* tail is that run's own allocation cost, not inherited debt.
-> - **Live-set** (the GC-tuning note below): what each collection costs while a built tree
->   is *held* in memory — the cost a skipped collection avoids re-paying.
+> - **Back-to-back samples** (Tables 1–3): each sample inherits the garbage the previous
+>   one left behind — the *(GC x)* tail is what a working session actually pays.
+> - **Freshly collected heap** (Table 4): every run starts right after a full collection —
+>   the *(GC x)* tail is that run's own allocation cost, with no inherited debt.
+> - **With a built tree held in memory** (the GC-tuning note below): what each collection
+>   costs while a tree stays live — the cost a skipped collection avoids re-paying.
 >
 > Across all three, the GC share is the volatile part; the GC-free remainder reproduces
 > within a few percent and is the number to compare across sessions or versions.

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ doc = read("file.xml", LazyNode)
 
 `LazyNode` supports the same read-only interface as `Node`: `nodetype`, `tag`, `attributes`, `value`, `children`, `is_simple`, `simple_value`, plus integer and string indexing.
 
-`LazyNode` is for *partial* reads only: opening is a no-op wrapper (~0.5 µs whatever the file size), a traversal pays only for the bytes it steps over — descending to a target is O(bytes before it), so reaching this 14 MB file's root element costs ~4 µs — and nothing is cached, so repeated visits pay again. Unbeatable for descents and kilobyte-scale documents; for whole-tree walks (283 ms vs ~56/~95 ms build+walk on the 14 MB corpus below) and repeated queries, build `FlatNode` or `Node` instead — see [Performance by access pattern](#performance-by-access-pattern).
+`LazyNode` is for *partial* reads only: opening is a no-op wrapper (~0.5 µs whatever the file size), a traversal pays only for the bytes it steps over — descending to a target is O(bytes before it), so reaching this 14 MB file's root element costs ~4 µs — and nothing is cached, so repeated visits pay again. Unbeatable for descents and kilobyte-scale documents; for whole-tree walks (279 ms vs ~56/~103 ms build+walk on the 14 MB corpus below) and repeated queries, build `FlatNode` or `Node` instead — see [Performance by access pattern](#performance-by-access-pattern).
 
 For streaming and high-throughput workloads, several extra accessors avoid materializing intermediate collections:
 
@@ -333,19 +333,19 @@ end
 
 # Performance by access pattern
 
-One number cannot rank the readers — cost depends on what you do with the document. Same ~14 MB / 882 K-node XMark document as the cross-library table below (source: [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl); **lower is better**; median of repeated runs at the default settings):
+One number cannot rank the readers — cost depends on what you do with the document. Same ~14 MB / 882 K-node XMark document as the cross-library table below (source: [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl); **lower is better**; BenchmarkTools `@benchmark` medians at default parameters):
 
 | | build | walk every node | extract all values | DOM size in memory |
 |---|--:|--:|--:|--:|
-| `Cursor` | — (streams) | 35.8 ms (its one scan) | — | — (no DOM) |
-| `LazyNode` | ~0 (a wrapper) | 283 ms (re-tokenizes) | — | — (source only) |
-| `FlatNode` | 53.4 ms | 2.9 ms | 6.5 ms | 54.9 MiB |
-| `Node` | 90.0 ms | 5.1 ms | 5.1 ms | 71.6 MiB |
-| EzXML (libxml2) | 37.7 ms | — | — | — |
+| `Cursor` | — (streams) | 35.7 ms (its one scan) | — | — (no DOM) |
+| `LazyNode` | ~0 (a wrapper) | 279 ms (re-tokenizes) | — | — (source only) |
+| `FlatNode` | 53.2 ms | 2.97 ms | 6.6 ms | 54.9 MiB |
+| `Node` | 99.8 ms | 3.27 ms | 3.6 ms | 71.6 MiB |
+| EzXML (libxml2) | 47.5 ms | — | — | — |
 
-Reading the table: `Cursor`'s walk *is* its parse — one tokenizing scan, nothing retained. `LazyNode` opens for free and pays per node visited — unbeatable for touching a *fraction* of a large document, and (as the walk column shows) the wrong tool for visiting all of it. `FlatNode` builds ~1.7× faster than `Node`, walks ~1.8× faster, holds ~25% less memory, and its `parent`/`depth` are O(1) where `Node` searches from the root; pure value extraction on an already-built tree is the one pattern where `Node`'s direct fields still win, by ~30%. libxml2 still builds fastest — the remaining gap is materialization, not scanning (see [PERFORMANCE-v0.4.md](PERFORMANCE-v0.4.md)).
+Reading the table: `Cursor`'s walk *is* its parse — one tokenizing scan, nothing retained. `LazyNode` opens for free and pays per node visited — unbeatable for touching a *fraction* of a large document, and (as the walk column shows) the wrong tool for visiting all of it. `FlatNode` builds ~1.9× faster than `Node`, holds ~23% less memory, and its `parent`/`depth` are O(1) where `Node` searches from the root; whole-tree walks are near-parity (`Node`'s exact-size children vectors sharpened its locality), and pure value extraction on an already-built tree is the one pattern where `Node`'s direct fields win outright, by ~1.8×. libxml2 still builds fastest — ~1.1× vs `FlatNode` — and the remaining gap is materialization, not scanning (see [PERFORMANCE-v0.4.md](PERFORMANCE-v0.4.md)).
 
-_Measured 2026-08-01, Apple M5 (single-threaded), Julia 1.12.6, EzXML 1.2.3._
+_Measured 2026-08-02, Apple M5 (single-threaded), Julia 1.12.6, EzXML 1.2.3; BenchmarkTools medians._
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ doc = read("file.xml", LazyNode)
 
 `LazyNode` supports the same read-only interface as `Node`: `nodetype`, `tag`, `attributes`, `value`, `children`, `is_simple`, `simple_value`, plus integer and string indexing.
 
-`LazyNode` is for *partial* reads only: opening is a no-op wrapper (~0.5 µs whatever the file size), a traversal pays only for the bytes it steps over — descending to a target is O(bytes before it), so reaching this 14 MB file's root element costs ~4 µs — and nothing is cached, so repeated visits pay again. Unbeatable for descents and kilobyte-scale documents; for whole-tree walks (283 ms vs ~55/~99 ms build+walk on the 14 MB corpus below) and repeated queries, build `FlatNode` or `Node` instead — see [Performance by access pattern](#performance-by-access-pattern).
+`LazyNode` is for *partial* reads only: opening is a no-op wrapper (~0.5 µs whatever the file size), a traversal pays only for the bytes it steps over — descending to a target is O(bytes before it), so reaching this 14 MB file's root element costs ~4 µs — and nothing is cached, so repeated visits pay again. Unbeatable for descents and kilobyte-scale documents; for whole-tree walks (283 ms vs ~56/~95 ms build+walk on the 14 MB corpus below) and repeated queries, build `FlatNode` or `Node` instead — see [Performance by access pattern](#performance-by-access-pattern).
 
 For streaming and high-throughput workloads, several extra accessors avoid materializing intermediate collections:
 
@@ -337,15 +337,15 @@ One number cannot rank the readers — cost depends on what you do with the docu
 
 | | build | walk every node | extract all values | DOM size in memory |
 |---|--:|--:|--:|--:|
-| `Cursor` | — (streams) | 35.7 ms (its one scan) | — | — (no DOM) |
+| `Cursor` | — (streams) | 35.8 ms (its one scan) | — | — (no DOM) |
 | `LazyNode` | ~0 (a wrapper) | 283 ms (re-tokenizes) | — | — (source only) |
-| `FlatNode` | 52.1 ms | 2.9 ms | 6.6 ms | 54.9 MiB |
-| `Node` | 93.4 ms | 5.2 ms | 5.4 ms | 80.0 MiB |
-| EzXML (libxml2) | 37.8 ms | — | — | — |
+| `FlatNode` | 53.4 ms | 2.9 ms | 6.5 ms | 54.9 MiB |
+| `Node` | 90.0 ms | 5.1 ms | 5.1 ms | 71.6 MiB |
+| EzXML (libxml2) | 37.7 ms | — | — | — |
 
-Reading the table: `Cursor`'s walk *is* its parse — one tokenizing scan, nothing retained. `LazyNode` opens for free and pays per node visited — unbeatable for touching a *fraction* of a large document, and (as the walk column shows) the wrong tool for visiting all of it. `FlatNode` builds ~1.8× faster than `Node`, walks ~1.8× faster, holds ~30% less memory, and its `parent`/`depth` are O(1) where `Node` searches from the root; pure value extraction on an already-built tree is the one pattern where `Node`'s direct fields still win, now by ~20%. libxml2 still builds fastest — the remaining gap is materialization, not scanning (see [PERFORMANCE-v0.4.md](PERFORMANCE-v0.4.md)).
+Reading the table: `Cursor`'s walk *is* its parse — one tokenizing scan, nothing retained. `LazyNode` opens for free and pays per node visited — unbeatable for touching a *fraction* of a large document, and (as the walk column shows) the wrong tool for visiting all of it. `FlatNode` builds ~1.7× faster than `Node`, walks ~1.8× faster, holds ~25% less memory, and its `parent`/`depth` are O(1) where `Node` searches from the root; pure value extraction on an already-built tree is the one pattern where `Node`'s direct fields still win, by ~30%. libxml2 still builds fastest — the remaining gap is materialization, not scanning (see [PERFORMANCE-v0.4.md](PERFORMANCE-v0.4.md)).
 
-_Measured 2026-07-30, Apple M5 (single-threaded), Julia 1.12.6, EzXML 1.2.3._
+_Measured 2026-08-01, Apple M5 (single-threaded), Julia 1.12.6, EzXML 1.2.3._
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -351,16 +351,16 @@ _Measured 2026-08-02, Apple M5 (single-threaded), Julia 1.12.6, EzXML 1.2.3; Ben
 
 # Benchmarks
 
-Source: [`benchmarks/benchmarks.jl`](benchmarks/benchmarks.jl). Data: `books.xml` (~4 KB) and a generated XMark auction document (~14 MB). The XML.jl column uses `Node` throughout — the full mutable DOM, the like-for-like counterpart of the libxml2 DOMs the C wrappers build; [Performance by access pattern](#performance-by-access-pattern) above shows how the other readers change the picture. Median time, **lower is better.**
+Source: [`benchmarks/benchmarks.jl`](benchmarks/benchmarks.jl). Data: `books.xml` (~4 KB) and a generated XMark auction document (~14 MB). The XML.jl column uses `Node` throughout — the full mutable DOM, the like-for-like counterpart of the libxml2 DOMs the C wrappers build; [Performance by access pattern](#performance-by-access-pattern) above shows how the other readers change the picture. BenchmarkTools median time, **lower is better.**
 
 | Benchmark | XML.jl | EzXML | LightXML | XMLDict |
 |---|--:|--:|--:|--:|
-| Parse, small | 0.022 ms | 0.013 ms | 0.011 ms | 0.110 ms |
-| Parse, medium | 110 ms | 46.8 ms | 47.1 ms | 348 ms |
-| Write, small | 0.0056 ms | 0.0059 ms | 0.059 ms | — |
-| Write, medium | 27.7 ms | 21.1 ms | 29.1 ms | — |
-| Collect tags, small | 0.00037 ms | 0.0011 ms | 0.0018 ms | — |
-| Collect tags, medium | 5.63 ms | 10.4 ms | 12.9 ms | — |
+| Parse, small | 0.0212 ms | 0.0132 ms | 0.0122 ms | 0.11 ms |
+| Parse, medium | 95.5 ms | 47.3 ms | 37.5 ms | 347 ms |
+| Write, small | 0.00569 ms | 0.00572 ms | 0.0583 ms | — |
+| Write, medium | 25.7 ms | 20.7 ms | 29.1 ms | — |
+| Collect tags, small | 0.000372 ms | 0.00112 ms | 0.00183 ms | — |
+| Collect tags, medium | 4.79 ms | 10.4 ms | 13.2 ms | — |
 
 EzXML and LightXML wrap libxml2 (C): faster on raw parse, slower on in-Julia traversal.
 Times include garbage collection; [PERFORMANCE](PERFORMANCE-v0.4.md) breaks each of its rows
@@ -368,4 +368,4 @@ into the stable GC-free work and the per-session GC share.
 
 For the per-access-pattern decomposition (streaming / partial reads / full DOM / stage breakdown) and the theory behind these numbers, see [**PERFORMANCE-v0.4.md**](PERFORMANCE-v0.4.md).
 
-_Measured 2026-07-22, Apple M5 (single-threaded), Julia 1.12.6; EzXML 1.2.3 / LightXML 0.9.3 (libxml2 2.15.3), XMLDict 0.4.2. Source: [`benchmarks/benchmarks.jl`](benchmarks/benchmarks.jl)._
+_Measured 2026-08-02, Apple M5 (single-threaded), Julia 1.12.6; EzXML 1.2.3 / LightXML 0.9.3 (libxml2 2.15.3), XMLDict 0.4.2. Source: [`benchmarks/benchmarks.jl`](benchmarks/benchmarks.jl)._

--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -50,7 +50,10 @@ const SSNode = Node{SubString{String}}
 @add_benchmark "Parse (medium)" "XML.jl" parse($medium_xml, Node)
 @add_benchmark "Parse (medium)" "XML.jl (SS)" parse($medium_xml, SSNode)
 @add_benchmark "Parse (medium)" "EzXML" EzXML.parsexml($medium_xml)
-@add_benchmark "Parse (medium)" "LightXML" LightXML.parse_string($medium_xml)
+# LightXML attaches no finalizer, so an unfreed parse leaks its whole C tree — at ~80 MB
+# per 14 MB parse and hundreds of samples that pages the machine mid-cell. The medium and
+# read-file cells therefore free per sample (teardown, untimed; evals=1 at this duration).
+@add_benchmark "Parse (medium)" "LightXML" (d[] = LightXML.parse_string($medium_xml)) setup=(d = Ref{Any}(nothing)) teardown=(d[] === nothing || LightXML.free(d[]); d[] = nothing)
 @add_benchmark "Parse (medium)" "XMLDict" XMLDict.xml_dict($medium_xml)
 
 #-----------------------------------------------------------------------------# Write (small)
@@ -66,7 +69,7 @@ const SSNode = Node{SubString{String}}
 #-----------------------------------------------------------------------------# Read from file
 @add_benchmark "Read file" "XML.jl" read($medium_file, Node)
 @add_benchmark "Read file" "EzXML" EzXML.readxml($medium_file)
-@add_benchmark "Read file" "LightXML" LightXML.parse_file($medium_file)
+@add_benchmark "Read file" "LightXML" (d[] = LightXML.parse_file($medium_file)) setup=(d = Ref{Any}(nothing)) teardown=(d[] === nothing || LightXML.free(d[]); d[] = nothing)
 
 #-----------------------------------------------------------------------------# Collect element tags
 function xml_collect_tags(node)

--- a/benchmarks/benchmarks_results.md
+++ b/benchmarks/benchmarks_results.md
@@ -2,84 +2,84 @@
 
 ```
 Parse (small)
-	XML.jl             0.0216 ms
-	XML.jl (SS)        0.0196 ms
-	EzXML              0.0136 ms  (XML.jl 58.9% slower)
-	LightXML           0.0112 ms  (XML.jl 91.8% slower)
-	XMLDict             0.112 ms  (XML.jl 80.7% faster)
+	XML.jl             0.0212 ms
+	XML.jl (SS)        0.0195 ms
+	EzXML              0.0132 ms  (XML.jl 60.6% slower)
+	LightXML           0.0122 ms  (XML.jl 73.1% slower)
+	XMLDict              0.11 ms  (XML.jl 80.7% faster)
 
 Parse (medium)
-	XML.jl              115.0 ms
-	XML.jl (SS)         107.0 ms
-	EzXML                47.2 ms  (XML.jl 143.3% slower)
-	LightXML             47.5 ms  (XML.jl 141.8% slower)
-	XMLDict             352.0 ms  (XML.jl 67.3% faster)
+	XML.jl               95.5 ms
+	XML.jl (SS)          90.9 ms
+	EzXML                47.3 ms  (XML.jl 102.1% slower)
+	LightXML             37.5 ms  (XML.jl 154.7% slower)
+	XMLDict             347.0 ms  (XML.jl 72.5% faster)
 
 Write (small)
-	XML.jl            0.00572 ms
-	EzXML             0.00574 ms  (~same)
-	LightXML           0.0573 ms  (XML.jl 90.0% faster)
+	XML.jl            0.00569 ms
+	EzXML             0.00572 ms  (~same)
+	LightXML           0.0583 ms  (XML.jl 90.2% faster)
 
 Write (medium)
-	XML.jl               28.3 ms
-	EzXML                21.1 ms  (XML.jl 34.3% slower)
-	LightXML             30.3 ms  (XML.jl 6.5% faster)
+	XML.jl               25.7 ms
+	EzXML                20.7 ms  (XML.jl 24.5% slower)
+	LightXML             29.1 ms  (XML.jl 11.7% faster)
 
 Read file
-	XML.jl              110.0 ms
-	EzXML                60.0 ms  (XML.jl 83.6% slower)
-	LightXML             70.2 ms  (XML.jl 56.9% slower)
+	XML.jl               83.9 ms
+	EzXML                60.3 ms  (XML.jl 39.2% slower)
+	LightXML             39.5 ms  (XML.jl 112.3% slower)
 
 Collect tags (small)
-	XML.jl           0.000371 ms
-	EzXML             0.00109 ms  (XML.jl 65.8% faster)
-	LightXML           0.0018 ms  (XML.jl 79.4% faster)
+	XML.jl           0.000372 ms
+	EzXML             0.00112 ms  (XML.jl 66.8% faster)
+	LightXML          0.00183 ms  (XML.jl 79.7% faster)
 
 Collect tags (medium)
-	XML.jl               5.63 ms
-	EzXML                10.6 ms  (XML.jl 46.7% faster)
-	LightXML             12.7 ms  (XML.jl 55.5% faster)
+	XML.jl               4.79 ms
+	EzXML                10.4 ms  (XML.jl 54.1% faster)
+	LightXML             13.2 ms  (XML.jl 63.8% faster)
 
 Parse SST (LazyNode)
 	XML.jl            4.96e-6 ms
-	Node (for ref)       17.1 ms  (XML.jl 100.0% faster)
+	Node (for ref)       17.5 ms  (XML.jl 100.0% faster)
 
 Parse worksheet (LazyNode)
 	XML.jl            4.96e-6 ms
 	Node (for ref)       28.5 ms  (XML.jl 100.0% faster)
 
 SST: write each <si>
-	LazyNode + write (zero-copy)     33.6 ms
-	LazyNode + write (normalize)     71.7 ms
-	Node (for ref)       5.58 ms
+	LazyNode + write (zero-copy)     33.8 ms
+	LazyNode + write (normalize)     73.3 ms
+	Node (for ref)       5.56 ms
 
 SST: unformatted text
-	LazyNode + is_simple_value     39.3 ms
-	Node (for ref)       2.39 ms
+	LazyNode + is_simple_value     40.0 ms
+	Node (for ref)       2.38 ms
 
 Worksheet: collect rows
-	children() (fresh Vector each call)     36.6 ms
-	children!(buf, n) (reused buffer)     36.4 ms
+	children() (fresh Vector each call)     36.1 ms
+	children!(buf, n) (reused buffer)     36.5 ms
 
 Worksheet: attribute scan
-	eachattribute        36.3 ms
-	attributes() (materialize dict)     36.5 ms
+	eachattribute        36.0 ms
+	attributes() (materialize dict)     36.1 ms
 
 Worksheet: single attr fetch
-	get(c, "r", "")      36.7 ms
-	attributes(c)["r"]     36.2 ms
+	get(c, "r", "")      37.0 ms
+	attributes(c)["r"]     36.3 ms
 
 Worksheet: <v> value
-	is_simple_value      36.6 ms
-	is_simple + simple_value     36.5 ms
+	is_simple_value      36.1 ms
+	is_simple + simple_value     36.3 ms
 
 XLSX sst_load! (end-to-end)
-	LazyNode             53.3 ms
-	LazyNode (entity-heavy)     47.4 ms
+	LazyNode             53.0 ms
+	LazyNode (entity-heavy)     49.4 ms
 
 XLSX cell read (end-to-end)
-	numeric ws           36.6 ms
-	string ws            33.6 ms
+	numeric ws           36.1 ms
+	string ws            33.7 ms
 
 ```
 

--- a/benchmarks/flatnode_bench.jl
+++ b/benchmarks/flatnode_bench.jl
@@ -1,63 +1,73 @@
-# FlatNode exhaustive in-package benchmark — by regime, median of N runs at the default
-# well-formedness level, vs Node/LazyNode/EzXML.
-#   julia benchmarks/flatnode_bench.jl   (self-contained temp env: dev XML from this checkout + EzXML)
-using Pkg
-Pkg.activate(; temp = true, io = devnull)
-Pkg.develop(path = joinpath(@__DIR__, ".."), io = devnull)
-Pkg.add("EzXML", io = devnull)
-using XML, EzXML, Statistics
+# Per-reader benchmark behind Table 4 of PERFORMANCE-v0.4.md and the README
+# "Performance by access pattern" table — BenchmarkTools throughout, default
+# parameters, 5 s budget per cell: samples run back-to-back, each printed number
+# is the median sample's time with the median GC share as its "(GC x)" tail
+# (omitted below 0.05 ms). "alloc" is one call's allocation total (Julia heap);
+# "retained" is Base.summarysize of the live DOM — facts, not timings.
+#
+#   julia --project=benchmarks benchmarks/flatnode_bench.jl
+#   julia --project=benchmarks benchmarks/flatnode_bench.jl --gc-only
+#   julia --project=benchmarks --gcthreads=4 benchmarks/flatnode_bench.jl --gc-only
+#
+# --gc-only measures one thing: a full collection with the built `Node` tree as
+# the live set (the GC-tuning [!TIP] of PERFORMANCE-v0.4.md) — run it with and
+# without --gcthreads to reproduce the pair of figures quoted there.
+using XML, EzXML, BenchmarkTools
+
+BenchmarkTools.DEFAULT_PARAMETERS.seconds = 5
 
 const xmark = joinpath(@__DIR__, "data", "xmark.xml")
 const xml = read(xmark, String)
-println("corpus: ", basename(xmark), " (", round(ncodeunits(xml) / 2^20, digits = 1), " MiB)")
+println("corpus: ", basename(xmark), " (", round(ncodeunits(xml) / 2^20, digits = 1),
+        " MiB)   julia ", VERSION, "   gcthreads ", Threads.ngcthreads())
 
-# The median RUN's (elapsed, gctime) pair — runs sorted by elapsed, middle one picked whole,
-# so the GC figure belongs to the same run as the time it decomposes. GC.gc() first: each run
-# starts from a clean heap, so gctime is the run's own allocation cost, not inherited debt.
-function medN(f, n = 7)
-    runs = [begin GC.gc(); t = @timed f(); (t.time, t.gctime) end for _ in 1:n]
-    sort!(runs; by = first)
-    runs[cld(n, 2)]
-end
-_gctail(gc) = gc * 1000 < 0.05 ? "" : string(" (GC ", round(gc * 1000, digits = 1), ")")
-allocs(f) = (GC.gc(); Base.gc_num().allocd; a0 = Base.gc_bytes(); f(); Base.gc_bytes() - a0)
-
-# ── build ──
-fbuild() = parse(xml, FlatNode)
-nbuild() = parse(xml, Node)
-ezbuild() = EzXML.parsexml(xml)
-for (nm, f) in ["FlatNode" => fbuild, "Node" => nbuild, "EzXML" => ezbuild]
-    el, gc = medN(f)
-    println("build   ", rpad(nm, 9), lpad(round(el * 1000, digits = 1), 8), " ms", _gctail(gc))
+_tail(gc) = gc < 0.05 ? "" : string(" (GC ", round(gc, digits = 1), ")")
+function cell(label, b; alloc = false)
+    m = median(b)
+    print(rpad(label, 22), lpad(round(m.time / 1e6, digits = 2), 9), " ms",
+          rpad(_tail(m.gctime / 1e6), 12))
+    alloc && print(lpad(round(b.memory / 2^20, digits = 1), 7), " MiB alloc")
+    println()
 end
 
-# ── traverse (count nodes via each reader's handles) ──
-const F = fbuild(); const N = nbuild(); const EZ = ezbuild()
-const L = parse(xml, LazyNode)
-function lwalk(n, c = Ref(0))
-    c[] += 1
-    for ch in XML.eachchildnode(n); lwalk(ch, c); end
-    c[]
-end
-function fwalk(n, c = Ref(0))
-    c[] += 1
-    for ch in XML.eachchildnode(n); fwalk(ch, c); end
-    c[]
-end
 function nwalk(n, c = Ref(0))
     c[] += 1
     for ch in children(n); nwalk(ch, c); end
     c[]
 end
-function curwalk()
-    c = Cursor(xml); n = 0
+
+if "--gc-only" in ARGS
+    const N0 = parse(xml, Node)
+    println("live tree: ", nwalk(N0), " nodes")
+    cell("GC full, Node live", @benchmark GC.gc(true) evals = 1)
+    exit(0)
+end
+
+# ── build (the whole `parse` call) ──
+cell("build FlatNode", @benchmark(parse($xml, FlatNode)); alloc = true)
+cell("build Node",     @benchmark(parse($xml, Node));     alloc = true)
+cell("build EzXML",    @benchmark(EzXML.parsexml($xml)))   # C-heap tree: Julia alloc not meaningful
+
+# ── handles for the access benchmarks ──
+const F = parse(xml, FlatNode)
+const N = parse(xml, Node)
+const L = parse(xml, LazyNode)
+flatroot() = FlatNode(F.store, Int32(1))
+
+function fwalk(n, c = Ref(0))
+    c[] += 1
+    for ch in XML.eachchildnode(n); fwalk(ch, c); end
+    c[]
+end
+function lwalk(n, c = Ref(0))
+    c[] += 1
+    for ch in XML.eachchildnode(n); lwalk(ch, c); end
+    c[]
+end
+function curwalk(s)
+    c = Cursor(s); n = 0
     while next!(c) !== nothing; n += 1; end
     n
-end
-println("nodes: flat=", fwalk(FlatNode(F.store, Int32(1))), " node=", nwalk(N), " lazy=", lwalk(L))
-for (nm, f) in ["FlatNode" => () -> fwalk(FlatNode(F.store, Int32(1))), "Node" => () -> nwalk(N), "Cursor" => curwalk, "LazyNode" => () -> lwalk(L)]
-    el, gc = medN(f)
-    println("walk    ", rpad(nm, 9), lpad(round(el * 1000, digits = 2), 8), " ms", _gctail(gc))
 end
 
 # ── extract (tag/value byte sums through the public accessors) ──
@@ -73,18 +83,18 @@ function nextract(n, acc = Ref(0))
     for ch in children(n); nextract(ch, acc); end
     acc[]
 end
-println("extract sums: flat=", fextract(FlatNode(F.store, Int32(1))), " node=", nextract(N))
-for (nm, f) in ["FlatNode" => () -> fextract(FlatNode(F.store, Int32(1))), "Node" => () -> nextract(N)]
-    el, gc = medN(f)
-    println("extract ", rpad(nm, 9), lpad(round(el * 1000, digits = 2), 8), " ms", _gctail(gc))
-end
 
-# ── retained + build allocations ──
-println("retained  FlatNode ", lpad(round(Base.summarysize(F.store) / 2^20, digits = 1), 7), " MiB   ",
-        "Node ", lpad(round(Base.summarysize(N) / 2^20, digits = 1), 7), " MiB")
-println("buildalloc FlatNode ", lpad(round(allocs(fbuild) / 2^20, digits = 1), 6), " MiB   ",
-        "Node ", lpad(round(allocs(nbuild) / 2^20, digits = 1), 6), " MiB")
+println("nodes: flat=", fwalk(flatroot()), " node=", nwalk(N), " lazy=", lwalk(L),
+        " cursor=", curwalk(xml))
+println("extract sums: flat=", fextract(flatroot()), " node=", nextract(N))
 
-# ── GC pressure: full collection time with the tree live ──
-gcms(x) = (GC.gc(); t = @elapsed GC.gc(true); t * 1000)
-println("GC full  with FlatNode live ", round(gcms(F), digits = 2), " ms   with Node live ", round(gcms(N), digits = 2), " ms")
+cell("walk FlatNode",  @benchmark fwalk(flatroot()))
+cell("walk Node",      @benchmark nwalk($N))
+cell("walk Cursor",    @benchmark curwalk($xml))
+cell("walk LazyNode",  @benchmark lwalk($L))
+
+cell("extract FlatNode", @benchmark fextract(flatroot()))
+cell("extract Node",     @benchmark nextract($N))
+
+println("retained  FlatNode ", lpad(round(Base.summarysize(F.store) / 2^20, digits = 1), 7),
+        " MiB   Node ", lpad(round(Base.summarysize(N) / 2^20, digits = 1), 7), " MiB")

--- a/benchmarks/profile.jl
+++ b/benchmarks/profile.jl
@@ -31,7 +31,7 @@ const SSNode = Node{SubString{String}}
 ms(b)  = round(median(b).time / 1e6, digits = 2)
 mib(b) = round(b.memory / 2^20, digits = 1)
 # Each line decomposes its median: total (the user-lived figure, GC draws included) and the
-# GC share of that median sample — the total minus it is the stable, reproducible work time.
+# median GC share — the total minus it is the stable, reproducible work time.
 function row(label, b)
     gc = median(b).gctime / 1e6
     tail = gc < 0.05 ? "" : string(" (GC ", round(gc, digits = 1), ")")

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -58,8 +58,16 @@ end
 _to(::Type{String}, s::AbstractString) = String(s)
 _to(::Type{SubString{String}}, s::SubString{String}) = s
 
-# Collapse an empty Vector to `nothing` so Node fields store "absent" canonically.
-_nothingify(v::Vector) = isempty(v) ? nothing : v
+# Slice the run `scratch[mark+1:end]` out as one exact-size Vector — or `nothing` when the
+# run is empty, so Node fields store "absent" canonically and the empty case allocates
+# nothing at all — then truncate the scratch back to the mark (#107).
+function _take_slice!(scratch::Vector{T}, mark::Int) where {T}
+    n = length(scratch)
+    n == mark && return nothing
+    out = scratch[(mark + 1):n]
+    resize!(scratch, mark)
+    out
+end
 
 # Decode the raw bytes of a TEXT/ATTR_VALUE token into the parser's storage type. When the
 # tokenizer guarantees no `&` was seen (`has_entities=false`), we skip the entity-decode
@@ -139,9 +147,14 @@ end
 # away on :lenient.
 function _parse(xml::String, ::Type{S}, convert_text::F, ::Val{W}) where {S, F, W}
     tags = S[]
-    attrs_stack = Vector{Pair{S,S}}[]
-    children_stack = Vector{Vector{Node{S}}}()
-    push!(children_stack, Node{S}[])
+    # The value-stack discipline of stack parsers (#107): constituents accumulate on two
+    # parse-wide scratch vectors, integer marks delimit the currently-open element's run,
+    # and each close slices its exact-size run back out — no per-element vector, no
+    # push!-growth churn, and an empty run materializes as `nothing` without allocating.
+    scratch_attrs = Pair{S,S}[]
+    scratch_children = Node{S}[]
+    attr_marks = Int[]
+    child_marks = Int[]
 
     pending_attr_name = SubString(xml, 1, 0)
     decl_attrs = nothing
@@ -156,30 +169,30 @@ function _parse(xml::String, ::Type{S}, convert_text::F, ::Val{W}) where {S, F, 
             W === :strict && _check_chars_strict(rawtext)
             W === :strict && token.has_entities && _check_charrefs_strict(rawtext)
             v = _text_value(S, rawtext, token.has_entities, convert_text)
-            push!(last(children_stack), Node{S}(Text, nothing, nothing, v, nothing))
+            push!(scratch_children, Node{S}(Text, nothing, nothing, v, nothing))
 
         elseif k === TokenKinds.OPEN_TAG
             nm = tag_name(token, xml)
             W !== :lenient && (isempty(nm) || !_is_name_start(first(nm))) &&
                 error("not well-formed: invalid element name \"$nm\"")
             push!(tags, _to(S, nm))
-            push!(attrs_stack, Pair{S,S}[])
-            push!(children_stack, Node{S}[])
+            push!(attr_marks, length(scratch_attrs))
+            push!(child_marks, length(scratch_children))
 
         elseif k === TokenKinds.SELF_CLOSE
             t = pop!(tags)
-            a = pop!(attrs_stack)
-            pop!(children_stack)
-            push!(last(children_stack), Node{S}(Element, t, _nothingify(a), nothing, nothing))
+            a = _take_slice!(scratch_attrs, pop!(attr_marks))
+            pop!(child_marks)   # a self-closing element cannot have accumulated children
+            push!(scratch_children, Node{S}(Element, t, a, nothing, nothing))
 
         elseif k === TokenKinds.CLOSE_TAG
             close_name = tag_name(token, xml)
             isempty(tags) && error("Closing tag </$close_name> with no matching open tag.")
             t = pop!(tags)
             t == close_name || error("Mismatched tags: expected </$t>, got </$close_name>.")
-            a = pop!(attrs_stack)
-            c = pop!(children_stack)
-            push!(last(children_stack), Node{S}(Element, t, _nothingify(a), nothing, isempty(c) ? nothing : c))
+            a = _take_slice!(scratch_attrs, pop!(attr_marks))
+            c = _take_slice!(scratch_children, pop!(child_marks))
+            push!(scratch_children, Node{S}(Element, t, a, nothing, c))
 
         elseif k === TokenKinds.ATTR_NAME
             pending_attr_name = raw(token, xml)
@@ -194,19 +207,21 @@ function _parse(xml::String, ::Type{S}, convert_text::F, ::Val{W}) where {S, F, 
             if decl_attrs !== nothing
                 any(p -> first(p) == name, decl_attrs) && error("Duplicate attribute: $name")
                 push!(decl_attrs, name => val)
-            elseif !isempty(attrs_stack)
-                any(p -> first(p) == name, last(attrs_stack)) && error("Duplicate attribute: $name")
-                push!(last(attrs_stack), name => val)
+            elseif !isempty(attr_marks)
+                for i in (attr_marks[end] + 1):length(scratch_attrs)
+                    first(scratch_attrs[i]) == name && error("Duplicate attribute: $name")
+                end
+                push!(scratch_attrs, name => val)
             end
 
         elseif k === TokenKinds.XML_DECL_OPEN
             decl_attrs = Pair{S,S}[]
 
         elseif k === TokenKinds.XML_DECL_CLOSE
-            W !== :lenient && length(children_stack) > 1 &&
+            W !== :lenient && !isempty(child_marks) &&
                 error("not well-formed: XML declaration inside element content")
             a = isempty(decl_attrs) ? nothing : decl_attrs
-            push!(last(children_stack), Node{S}(Declaration, nothing, a, nothing, nothing))
+            push!(scratch_children, Node{S}(Declaration, nothing, a, nothing, nothing))
             decl_attrs = nothing
 
         elseif k === TokenKinds.COMMENT_CONTENT
@@ -214,17 +229,17 @@ function _parse(xml::String, ::Type{S}, convert_text::F, ::Val{W}) where {S, F, 
             W === :strict && _check_chars_strict(cmt)
             W === :strict && occursin("--", cmt) && error("not well-formed: \"--\" within a comment")
             W === :strict && endswith(cmt, '-') && error("not well-formed: \"-\" immediately before \"-->\" in a comment (XML 1.0 §2.5)")
-            push!(last(children_stack), Node{S}(Comment, nothing, nothing, _to(S, cmt), nothing))
+            push!(scratch_children, Node{S}(Comment, nothing, nothing, _to(S, cmt), nothing))
 
         elseif k === TokenKinds.CDATA_CONTENT
             cdata = raw(token, xml)
             W === :strict && _check_chars_strict(cdata)
-            push!(last(children_stack), Node{S}(CData, nothing, nothing, _to(S, cdata), nothing))
+            push!(scratch_children, Node{S}(CData, nothing, nothing, _to(S, cdata), nothing))
 
         elseif k === TokenKinds.DOCTYPE_CONTENT
-            W !== :lenient && length(children_stack) > 1 &&
+            W !== :lenient && !isempty(child_marks) &&
                 error("not well-formed: DOCTYPE declaration inside element content")
-            push!(last(children_stack), Node{S}(DTD, nothing, nothing, _to(S, lstrip(raw(token, xml))), nothing))
+            push!(scratch_children, Node{S}(DTD, nothing, nothing, _to(S, lstrip(raw(token, xml))), nothing))
 
         elseif k === TokenKinds.PI_OPEN
             pending_pi_tag = pi_target(token, xml)
@@ -238,13 +253,15 @@ function _parse(xml::String, ::Type{S}, convert_text::F, ::Val{W}) where {S, F, 
             pending_pi_value = isempty(content) ? nothing : _to(S, content)
 
         elseif k === TokenKinds.PI_CLOSE
-            push!(last(children_stack), Node{S}(ProcessingInstruction, _to(S, pending_pi_tag), nothing, pending_pi_value, nothing))
+            push!(scratch_children, Node{S}(ProcessingInstruction, _to(S, pending_pi_tag), nothing, pending_pi_value, nothing))
         end
     end
 
     !isempty(tags) && error("Unclosed tags: $(join(tags, ", "))")
-    doc_children = only(children_stack)
-    W !== :lenient && _check_document_wellformed(doc_children)
-    Node{S}(Document, nothing, nothing, nothing, isempty(doc_children) ? nothing : doc_children)
+    # Slice the document level out too: the scratch keeps its historical peak capacity,
+    # which must not be retained by the returned tree.
+    doc_children = _take_slice!(scratch_children, 0)
+    W !== :lenient && doc_children !== nothing && _check_document_wellformed(doc_children)
+    Node{S}(Document, nothing, nothing, nothing, doc_children)
 end
 


### PR DESCRIPTION
Closes #107. `_parse` no longer allocates a fresh attributes and children vector per element: constituents accumulate on two parse-wide scratch stacks with integer marks, and each closing tag slices its run out as one exact-size vector — or `nothing`, allocation-free, when the run is empty (`_take_slice!` replaces `_nothingify`, whose collapse-to-`nothing` contract it absorbs). The document level is sliced out too: a vector's buffer keeps its historical peak capacity (the scratch peaks at 10 034 entries on the benchmark corpus, while the document ends with 4 top-level nodes), so returning the scratch directly would retain that peak for the tree's lifetime — the final slice copies the few top-level nodes and lets the big buffer die with the parse.

**The mechanism on a worked example** — `<a><b/><c>x</c></a>`; a mark is the scratch's saved length at open time, and every closing tag slices out the run beyond its mark:

| Event | Action | `scratch_children` | `child_marks` | tree built so far |
|---|---|---|---|---|
| `<a>` | push mark **0** | `[]` | `[0]` | — |
| `<b/>` | empty run → `nothing`; push **b** | `[b]` | `[0]` | `b` |
| `<c>` | push mark **1** | `[b]` | `[0, 1]` | `b` |
| `x` | push text node **x** | `[b, x]` | `[0, 1]` | `b` · `x` |
| `</c>` | slice `[2:2]` = `[x]` → children of `c`; push **c** | `[b, c]` | `[0]` | `b` · `c(x)` |
| `</a>` | slice `[1:2]` = `[b, c]` → children of `a`; push **a** | `[a]` | `[]` | `a(b, c(x))` |
| end | final slice `[1:1]` = `[a]` → `Document.children` | `[]` | `[]` | `Doc(a(b, c(x)))` |

Finished nodes wait side by side on the scratch; a closing tag is the moment its run becomes someone's children — the tree assembles bottom-up until the document swallows it.

Measured with BenchmarkTools on the 14 MB XMark corpus (`@benchmark parse($xml, Node)`, default settings, ~190 samples; Apple M5, Julia 1.12.6):

| | before | after | delta |
|---|--:|--:|--:|
| median time | 97.8 ms | 90.5 ms | **−7.5 %** |
| allocations | 2 907 421 | 2 526 927 | **−380 494 (−13 %)** |
| allocated memory | 122.3 MB | 99.8 MB | **−22.4 MB (−18 %)** |
| retained tree (`Base.summarysize`) | 80.0 MiB | 71.6 MiB | −8.4 MiB |

As expected from allocating less, the time win scales with how much garbage the collector has to manage: near zero with collections suppressed, larger than the median when the heap also holds earlier documents.

Semantics are unchanged — empty attribute/children sets still materialize as `nothing`, the duplicate-attribute check walks the open element's scratch run, and the full suite passes untouched. Tree integrity checked against the profiled references: 882 026 nodes and 9 968 541 extracted bytes, both exact.

**Documentation refresh (same PR).** Every timing in PERFORMANCE-v0.4.md and both README tables is now a BenchmarkTools `@benchmark` median — one protocol throughout. Tables 1–3 were already BenchmarkTools and are unchanged; `benchmarks/flatnode_bench.jl` is rewritten on `@benchmark`, and its `--gc-only` mode reproduces the GC-tuning pair (re-measured at ~56/~20 ms).

Knock-on effect of the build change itself: full walks of the built tree run ~1.4× faster (6.4 → 4.0 ms) — exact-size children vectors improve locality for every later traversal.

Retiring the old per-reader measurement script (median-of-N on a freshly collected heap) moved the cells it biased:

| Cell | old script | BenchmarkTools | why it moved |
|---|--:|--:|---|
| `Node` walk | 5.1 ms | 3.3 ms | the full collection before each run chilled the pointer-tree's caches |
| `Node` extract | 5.1 ms | 3.6 ms | same cache-chilling |
| EzXML build | 37.7 ms | 47.5 ms | per-run collection let finalizers free the previous C tree; back-to-back sampling keeps it |
| `FlatNode` build allocation | 73.7 MiB | 42.2 MiB | the old `gc_bytes`-delta probe was wrong — `@allocated` and `gc_num` agree on 42.2 |

The README cross-library table is refreshed on the same protocol: `Node` parse of the corpus drops 110 → 95.5 ms and collect-tags 5.63 → 4.79 ms. One fix to the benchmark suite is folded in: LightXML attaches no finalizer, so the suite's parse/read cells leaked their whole C tree per sample — enough to page the machine on long runs. They now free per sample (teardown, untimed), and LightXML's medium figures improve accordingly (parse 47.1 → 37.5 ms).
