### PR TITLE
Span-native tokens: drop the `prevind`/`nextind` `SubString` round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `benchmarks/flatnode_bench.jl` is rewritten accordingly (its `--gc-only` mode
   reproduces the GC-tuning pair) and the affected cells re-measured (#107).
 
+- **Span-native tokens: the tokenizer no longer round-trips byte spans through checked
+  `SubString` construction.** Emit sites build tokens directly from the integer scan
+  positions already in hand, and token views (`raw`, the tag/attribute/PI accessors) are
+  rebuilt by direct field construction — no `prevind`/`nextind` walks. Sound because every
+  span edge the scanner produces is an ASCII byte or EOF, hence a UTF-8 character boundary
+  by construction; full validation stays active under `--check-bounds=yes` (as in
+  `Pkg.test`). On the 14 MB benchmark corpus this cuts the pure lex ~32 % (37.4 → 25.6 ms)
+  and, through the shared tokenizer, every reader: `Node` build −17 %, `FlatNode` build
+  −35 % (it now out-builds libxml2), `Cursor` full stream −34 %, `LazyNode` full walk
+  −36 % — allocations unchanged: the removed round-trips were index arithmetic, not heap
+  traffic (#109).
+
 ## [0.4.4] - 2026-07-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   EzXML cells free their C tree per sample (untimed `finalize` teardown — cell timings
   verified unchanged), and dead finalizer-held trees are collected between cells, so a
   full suite run no longer pages the machine. Sub-millisecond rows of the README table
-  are now quoted in microseconds.
+  are now quoted in microseconds (#110).
 
 ## [0.4.4] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   −36 % — allocations unchanged: the removed round-trips were index arithmetic, not heap
   traffic (#109).
 
+- **The cross-library benchmark suite bounds its own C heap**: the medium and read-file
+  EzXML cells free their C tree per sample (untimed `finalize` teardown — cell timings
+  verified unchanged), and dead finalizer-held trees are collected between cells, so a
+  full suite run no longer pages the machine. Sub-millisecond rows of the README table
+  are now quoted in microseconds.
+
 ## [0.4.4] - 2026-07-31
 
 ### Added

--- a/PERFORMANCE-v0.4.md
+++ b/PERFORMANCE-v0.4.md
@@ -4,7 +4,7 @@ The headline cross-library figures live in the [README](README.md#benchmarks). T
 
 ## The theory behind "optimal"
 
-XML parsing splits into two language-theory levels, and v0.4 hits the **asymptotic lower bound** of each — the sense in which the lexer and parser are "optimal". The gap to a C library like [libxml2](https://en.wikipedia.org/wiki/Libxml2) is constant-factor (C tuning, a leaner non-Julia-heap tree), not asymptotic — and only on full-DOM building; at streaming, XML.jl is *faster* (below).
+XML parsing splits into two language-theory levels, and v0.4 hits the **asymptotic lower bound** of each — the sense in which the lexer and parser are "optimal". The gap to a C library like [libxml2](https://en.wikipedia.org/wiki/Libxml2) is constant-factor (C tuning, a leaner non-Julia-heap tree), not asymptotic — and only on the pointer-tree `Node` build; `FlatNode` now out-builds libxml2 (Table 4), and at streaming XML.jl is ~2× *faster* (Table 1).
 
 ### Level 1 — lexing is finite-state
 
@@ -28,7 +28,7 @@ One theoretical fine print: a textbook VPA has a *finite* stack alphabet, while 
 
 ### Julia-level constant factors
 
-The well-formedness level is a type parameter (`Val{W}`), so `:strict`/`:structural` checks are [dead-code-eliminated](https://en.wikipedia.org/wiki/Dead-code_elimination) when inactive (confirmed in the LLVM); `Node{S}` is parametric, so `parse(s, Node{SubString{String}})` — a supported method, exercised by the test suite and by the benchmarks behind the zero-copy row below — keeps **zero-copy views** while `parse(s, Node)` owns `String`s; a `has_entities` flag skips entity decoding when a token holds no `&`.
+The well-formedness level is a type parameter (`Val{W}`), so `:strict`/`:structural` checks are [dead-code-eliminated](https://en.wikipedia.org/wiki/Dead-code_elimination) when inactive (confirmed in the LLVM); `Node{S}` is parametric, so `parse(s, Node{SubString{String}})` — a supported method, exercised by the test suite and by the benchmarks behind the zero-copy row below — keeps **zero-copy views** while `parse(s, Node)` owns `String`s; a `has_entities` flag skips entity decoding when a token holds no `&`; and tokens are native byte spans — every span edge the scanner produces lands on an ASCII byte, provably a UTF-8 character boundary, so token views are rebuilt by direct field construction with no index walking.
 
 ## By access pattern
 
@@ -51,8 +51,8 @@ untouched; EzXML's `StreamReader` is libxml2's reader, paying FFI per event:
 
 | Stream | time (incl. GC) | memory |
 |---|--:|--:|
-| **XML.jl `Cursor`** | **46 ms** | **0.0 MiB** |
-| EzXML `StreamReader` | 68 ms (GC 0.8) | 36 MiB |
+| **XML.jl `Cursor`** | **31 ms** | **0.0 MiB** |
+| EzXML `StreamReader` | 66 ms (GC 0.9) | 36 MiB |
 
 _Table 1 — streaming: events only, no tree built._[^profile]
 
@@ -81,10 +81,10 @@ libxml2 wins the build; XML.jl materialises an 882 K-node Julia tree, EzXML a le
 
 | Full DOM extract | time (incl. GC) | memory |
 |---|--:|--:|
-| EzXML (libxml2) | **60 ms** | **54 MiB** |
-| LightXML (elements only) | 62 ms (GC 1.3) | 57 MiB |
-| XML.jl (`SubString`, zero-copy) | 93 ms (GC 20) | 95 MiB |
-| XML.jl (`String`) | 103 ms (GC 24) | 100 MiB |
+| EzXML (libxml2) | **61 ms** | **54 MiB** |
+| LightXML (elements only) | 63 ms (GC 1.4) | 57 MiB |
+| XML.jl (`SubString`, zero-copy) | 73 ms (GC 17) | 95 MiB |
+| XML.jl (`String`) | 82 ms (GC 20) | 100 MiB |
 | XML.jl **v0.3.9** (previous release) | 530 ms | 1422 MiB |
 
 _Table 2 — full-DOM extraction (parse + pull every tag/text), cross-library._[^profile]
@@ -94,9 +94,9 @@ _Table 2 — full-DOM extraction (parse + pull every tag/text), cross-library._[
 | Stage | time (incl. GC) | allocated |
 |---|--:|--:|
 | read file (I/O) | 0.6 ms | — |
-| **lex — the DFA** | **37.2 ms** | **0 B** |
-| parse → DOM (lex + build the tree, the VPA) | 99.2 ms (GC 23) | 100 MiB |
-| traverse a built tree | 4.0 ms | 0 B |
+| **lex — the DFA** | **25.6 ms** | **0 B** |
+| parse → DOM (lex + build the tree, the VPA) | 74.7 ms (GC 18) | 100 MiB |
+| traverse a built tree | 4.1 ms | 0 B |
 
 _Table 3 — the XML.jl pipeline, decomposed (`String` variant)._[^profile]
 
@@ -118,17 +118,17 @@ Measured on the same XMark document:
 
 | Full DOM, per reader | build (incl. GC) | walk every node | extract all values | DOM size in memory |
 |---|--:|--:|--:|--:|
-| **`FlatNode`** | **53.2 ms (GC 0.4)** | **2.97 ms** | 6.6 ms | **54.9 MiB** |
-| `Node` | 99.8 ms (GC 24) | 3.27 ms | **3.6 ms** | 71.6 MiB |
-| EzXML (libxml2) | 47.5 ms | — | — | — |
+| **`FlatNode`** | **34.9 ms (GC 0.1)** | **2.96 ms** | 6.6 ms | **54.9 MiB** |
+| `Node` | 81.1 ms (GC 23) | 3.49 ms | **3.6 ms** | 71.6 MiB |
+| EzXML (libxml2) | 45.8 ms | — | — | — |
 
 _Table 4 — per-reader full-DOM comparison; *build* is the whole `parse` call, and *DOM size* is the **retained** live tree (`Base.summarysize`), not allocations._[^flatbench]
 
-Build allocations: 42.2 MiB (`FlatNode`) vs 99.8 MiB (`Node` — down from 122.3 MiB before the scratch-stack build), and the libxml2 *build* gap is ~1.1× to `FlatNode`, ~2.1× to `Node`. The GC cells say why: `FlatNode`'s build allocates a handful of arrays instead of 882 K objects, so its median GC share is ~0.4 ms where `Node`'s is ~24 ms. Access on the finished stores is closer than the build: whole-tree walks are near-parity (2.97 vs 3.27 ms — exact-size children vectors sharpened `Node`'s cache locality), `parent`/`depth` stay O(1) index hops on `FlatNode` where `Node` must search down from the root, and pure value extraction on an already-built tree is the pattern where `Node`'s direct field reads win outright (3.6 vs 6.6 ms, ~1.8× — a computed `SubString` view per value is the flat store's toll).
+Build allocations: 42.2 MiB (`FlatNode`) vs 99.8 MiB (`Node` — down from 122.3 MiB before the scratch-stack build), and the *build* ranking now puts `FlatNode` ahead of libxml2 itself (~1.3× faster; `Node` remains ~1.8× behind the C library). The GC cells say why `FlatNode` builds so cheaply: its build allocates a handful of arrays instead of 882 K objects, so its median GC share is ~0.1 ms where `Node`'s is ~23 ms. Access on the finished stores: whole-tree walks are close (2.96 vs 3.49 ms — exact-size children vectors keep `Node`'s locality sharp), `parent`/`depth` stay O(1) index hops on `FlatNode` where `Node` must search down from the root, and pure value extraction on an already-built tree is the pattern where `Node`'s direct field reads win outright (3.6 vs 6.6 ms, ~1.8× — a computed `SubString` view per value is the flat store's toll).
 
 ### Choosing
 
-Stream / low-memory / read-only full-DOM / repeated traversal → **XML.jl**; a one-shot build-and-extract is the one job where a libxml2 binder still builds faster — ~1.1× vs `FlatNode`, ~2.1× vs `Node` — either way, pure Julia, no C dependency. Against its own past, v0.4 is **~5× faster and ~12× leaner than 0.3.9** (which used ~1.4 GiB for this file) — see [`benchmarks/profile.jl`](benchmarks/profile.jl), [`benchmarks/profile_vs_039.jl`](benchmarks/profile_vs_039.jl), [`benchmarks/compare.jl`](benchmarks/compare.jl).
+Stream / low-memory / read-only full-DOM / repeated traversal → **XML.jl**; `FlatNode` now out-builds the libxml2 binder (~1.3×: 34.9 vs 45.8 ms), and the C library's remaining win is the one-shot *`Node`* build-and-extract (~1.2–1.4× end-to-end, Table 2) — either way, pure Julia, no C dependency. Against its own past, v0.4 is **~5× faster and ~12× leaner than 0.3.9** (which used ~1.4 GiB for this file) — see [`benchmarks/profile.jl`](benchmarks/profile.jl), [`benchmarks/profile_vs_039.jl`](benchmarks/profile_vs_039.jl), [`benchmarks/compare.jl`](benchmarks/compare.jl).
 
 > [!NOTE]
 > **`:strict`** adds a character-range scan over text (a second O(content) pass); the overhead scales with the document's *text share* — ~1.1× on the markup-heavy XMark corpus, up to ~20× on a pure-text document; `:lenient` / `:structural` are unaffected.
@@ -144,6 +144,6 @@ Stream / low-memory / read-only full-DOM / repeated traversal → **XML.jl**; a 
 > computation. It trims GC pauses, not the materialization floor: the build's GC-free work
 > is unchanged.
 
-[^profile]: Tables 1–3: measured 2026-08-01 (the `v0.3.9` row: 2026-06-28), Apple M5 (single-threaded), Julia 1.12.6; EzXML 1.2.3 / LightXML 0.9.3 (libxml2 2.15.3); BenchmarkTools at a 5 s budget per cell. Source: [`benchmarks/profile.jl`](benchmarks/profile.jl).
+[^profile]: Tables 1–3: measured 2026-08-03 (the `v0.3.9` row: 2026-06-28), Apple M5 (single-threaded), Julia 1.12.6; EzXML 1.2.3 / LightXML 0.9.3 (libxml2 2.15.3); BenchmarkTools at a 5 s budget per cell. Source: [`benchmarks/profile.jl`](benchmarks/profile.jl).
 
-[^flatbench]: Table 4 (and the README access-pattern table): measured 2026-08-02, same machine, Julia and BenchmarkTools settings; source [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl).
+[^flatbench]: Table 4 (and the README access-pattern table): measured 2026-08-03, same machine, Julia and BenchmarkTools settings; source [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl).

--- a/README.md
+++ b/README.md
@@ -355,12 +355,12 @@ Source: [`benchmarks/benchmarks.jl`](benchmarks/benchmarks.jl). Data: `books.xml
 
 | Benchmark | XML.jl | EzXML | LightXML | XMLDict |
 |---|--:|--:|--:|--:|
-| Parse, small | 0.0212 ms | 0.0132 ms | 0.0122 ms | 0.11 ms |
-| Parse, medium | 95.5 ms | 47.3 ms | 37.5 ms | 347 ms |
-| Write, small | 0.00569 ms | 0.00572 ms | 0.0583 ms | — |
-| Write, medium | 25.7 ms | 20.7 ms | 29.1 ms | — |
-| Collect tags, small | 0.000372 ms | 0.00112 ms | 0.00183 ms | — |
-| Collect tags, medium | 4.79 ms | 10.4 ms | 13.2 ms | — |
+| Parse, small | 0.0158 ms | 0.0131 ms | 0.0114 ms | 0.11 ms |
+| Parse, medium | 77.4 ms | 46.1 ms | 39.0 ms | 352 ms |
+| Write, small | 0.00559 ms | 0.00577 ms | 0.0581 ms | — |
+| Write, medium | 24.4 ms | 21.5 ms | 28.3 ms | — |
+| Collect tags, small | 0.00037 ms | 0.00107 ms | 0.00183 ms | — |
+| Collect tags, medium | 4.81 ms | 8.99 ms | 13.1 ms | — |
 
 EzXML and LightXML wrap libxml2 (C): faster on raw parse, slower on in-Julia traversal.
 Times include garbage collection; [PERFORMANCE](PERFORMANCE-v0.4.md) breaks each of its rows
@@ -368,4 +368,4 @@ into the stable GC-free work and the per-session GC share.
 
 For the per-access-pattern decomposition (streaming / partial reads / full DOM / stage breakdown) and the theory behind these numbers, see [**PERFORMANCE-v0.4.md**](PERFORMANCE-v0.4.md).
 
-_Measured 2026-08-02, Apple M5 (single-threaded), Julia 1.12.6; EzXML 1.2.3 / LightXML 0.9.3 (libxml2 2.15.3), XMLDict 0.4.2. Source: [`benchmarks/benchmarks.jl`](benchmarks/benchmarks.jl)._
+_Measured 2026-08-03, Apple M5 (single-threaded), Julia 1.12.6; EzXML 1.2.3 / LightXML 0.9.3 (libxml2 2.15.3), XMLDict 0.4.2. Source: [`benchmarks/benchmarks.jl`](benchmarks/benchmarks.jl)._

--- a/README.md
+++ b/README.md
@@ -355,12 +355,12 @@ Source: [`benchmarks/benchmarks.jl`](benchmarks/benchmarks.jl). Data: `books.xml
 
 | Benchmark | XML.jl | EzXML | LightXML | XMLDict |
 |---|--:|--:|--:|--:|
-| Parse, small | 0.0158 ms | 0.0131 ms | 0.0114 ms | 0.11 ms |
-| Parse, medium | 77.4 ms | 46.1 ms | 39.0 ms | 352 ms |
-| Write, small | 0.00559 ms | 0.00577 ms | 0.0581 ms | — |
-| Write, medium | 24.4 ms | 21.5 ms | 28.3 ms | — |
-| Collect tags, small | 0.00037 ms | 0.00107 ms | 0.00183 ms | — |
-| Collect tags, medium | 4.81 ms | 8.99 ms | 13.1 ms | — |
+| Parse, small | 15.6 µs | 13.3 µs | 11.2 µs | 116 µs |
+| Parse, medium | 77.6 ms | 46.3 ms | 37.5 ms | 367 ms |
+| Write, small | 5.60 µs | 5.56 µs | 58.2 µs | — |
+| Write, medium | 26.8 ms | 21.2 ms | 30.1 ms | — |
+| Collect tags, small | 0.37 µs | 1.12 µs | 1.87 µs | — |
+| Collect tags, medium | 4.83 ms | 9.44 ms | 14.2 ms | — |
 
 EzXML and LightXML wrap libxml2 (C): faster on raw parse, slower on in-Julia traversal.
 Times include garbage collection; [PERFORMANCE](PERFORMANCE-v0.4.md) breaks each of its rows

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ doc = read("file.xml", LazyNode)
 
 `LazyNode` supports the same read-only interface as `Node`: `nodetype`, `tag`, `attributes`, `value`, `children`, `is_simple`, `simple_value`, plus integer and string indexing.
 
-`LazyNode` is for *partial* reads only: opening is a no-op wrapper (~0.5 µs whatever the file size), a traversal pays only for the bytes it steps over — descending to a target is O(bytes before it), so reaching this 14 MB file's root element costs ~4 µs — and nothing is cached, so repeated visits pay again. Unbeatable for descents and kilobyte-scale documents; for whole-tree walks (279 ms vs ~56/~103 ms build+walk on the 14 MB corpus below) and repeated queries, build `FlatNode` or `Node` instead — see [Performance by access pattern](#performance-by-access-pattern).
+`LazyNode` is for *partial* reads only: opening is a no-op wrapper (~0.5 µs whatever the file size), a traversal pays only for the bytes it steps over — descending to a target is O(bytes before it), so reaching this 14 MB file's root element costs ~4 µs — and nothing is cached, so repeated visits pay again. Unbeatable for descents and kilobyte-scale documents; for whole-tree walks (185 ms vs ~38/~85 ms build+walk on the 14 MB corpus below) and repeated queries, build `FlatNode` or `Node` instead — see [Performance by access pattern](#performance-by-access-pattern).
 
 For streaming and high-throughput workloads, several extra accessors avoid materializing intermediate collections:
 
@@ -337,15 +337,15 @@ One number cannot rank the readers — cost depends on what you do with the docu
 
 | | build | walk every node | extract all values | DOM size in memory |
 |---|--:|--:|--:|--:|
-| `Cursor` | — (streams) | 35.7 ms (its one scan) | — | — (no DOM) |
-| `LazyNode` | ~0 (a wrapper) | 279 ms (re-tokenizes) | — | — (source only) |
-| `FlatNode` | 53.2 ms | 2.97 ms | 6.6 ms | 54.9 MiB |
-| `Node` | 99.8 ms | 3.27 ms | 3.6 ms | 71.6 MiB |
-| EzXML (libxml2) | 47.5 ms | — | — | — |
+| `Cursor` | — (streams) | 25.3 ms (its one scan) | — | — (no DOM) |
+| `LazyNode` | ~0 (a wrapper) | 185 ms (re-tokenizes) | — | — (source only) |
+| `FlatNode` | 34.9 ms | 2.96 ms | 6.6 ms | 54.9 MiB |
+| `Node` | 81.1 ms | 3.49 ms | 3.6 ms | 71.6 MiB |
+| EzXML (libxml2) | 45.8 ms | — | — | — |
 
-Reading the table: `Cursor`'s walk *is* its parse — one tokenizing scan, nothing retained. `LazyNode` opens for free and pays per node visited — unbeatable for touching a *fraction* of a large document, and (as the walk column shows) the wrong tool for visiting all of it. `FlatNode` builds ~1.9× faster than `Node`, holds ~23% less memory, and its `parent`/`depth` are O(1) where `Node` searches from the root; whole-tree walks are near-parity (`Node`'s exact-size children vectors sharpened its locality), and pure value extraction on an already-built tree is the one pattern where `Node`'s direct fields win outright, by ~1.8×. libxml2 still builds fastest — ~1.1× vs `FlatNode` — and the remaining gap is materialization, not scanning (see [PERFORMANCE-v0.4.md](PERFORMANCE-v0.4.md)).
+Reading the table: `Cursor`'s walk *is* its parse — one tokenizing scan, nothing retained. `LazyNode` opens for free and pays per node visited — unbeatable for touching a *fraction* of a large document, and (as the walk column shows) the wrong tool for visiting all of it. `FlatNode` builds ~2.3× faster than `Node`, holds ~23% less memory, and its `parent`/`depth` are O(1) where `Node` searches from the root; whole-tree walks are close (`Node`'s exact-size children vectors keep its locality sharp), and pure value extraction on an already-built tree is the one pattern where `Node`'s direct fields win outright, by ~1.8×. `FlatNode` now out-builds even libxml2 (~1.3×), and `Node`'s remaining gap to the C library is materialization, not scanning (see [PERFORMANCE-v0.4.md](PERFORMANCE-v0.4.md)).
 
-_Measured 2026-08-02, Apple M5 (single-threaded), Julia 1.12.6, EzXML 1.2.3; BenchmarkTools medians._
+_Measured 2026-08-03, Apple M5 (single-threaded), Julia 1.12.6, EzXML 1.2.3; BenchmarkTools medians._
 
 <br>
 

--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -34,6 +34,7 @@ macro add_benchmark(kind, name, expr...)
         @info string($kind, " - ", $name)
         bench = @benchmark $(expr...)
         push!(df, (; kind=$kind, name=$name, bench))
+        GC.gc()  # run finalizers between cells so dead C trees never accumulate across the suite
     end))
 end
 
@@ -49,10 +50,17 @@ const SSNode = Node{SubString{String}}
 #-----------------------------------------------------------------------------# Parse (medium)
 @add_benchmark "Parse (medium)" "XML.jl" parse($medium_xml, Node)
 @add_benchmark "Parse (medium)" "XML.jl (SS)" parse($medium_xml, SSNode)
-@add_benchmark "Parse (medium)" "EzXML" EzXML.parsexml($medium_xml)
-# LightXML attaches no finalizer, so an unfreed parse leaks its whole C tree — at ~80 MB
-# per 14 MB parse and hundreds of samples that pages the machine mid-cell. The medium and
-# read-file cells therefore free per sample (teardown, untimed; evals=1 at this duration).
+# C-tree lifetime in the medium/read-file cells: LightXML attaches no finalizer, so an
+# unfreed parse leaks its whole tree outright; EzXML attaches one, but a benchmark loop
+# outruns the collector, so dead C trees pile up (gigabytes over a 5 s cell) until the
+# machine pages. These cells therefore release per sample (teardown, untimed; evals=1 at
+# this duration): LightXML.free / finalize for EzXML — both free C memory without touching
+# the Julia GC, so cell timings are unchanged. XMLDict's internal EzXML document is
+# unreachable from outside and its per-cell C residue is small (~50 MiB per sample at ~14
+# samples); it is left to the between-cell GC.gc() in @add_benchmark — a per-sample
+# collection would reset the young generation inside the cell and hide the GC cost the
+# allocation-heavy conversion pays in real use.
+@add_benchmark "Parse (medium)" "EzXML" (d[] = EzXML.parsexml($medium_xml)) setup=(d = Ref{Any}(nothing)) teardown=(d[] === nothing || finalize(d[]); d[] = nothing)
 @add_benchmark "Parse (medium)" "LightXML" (d[] = LightXML.parse_string($medium_xml)) setup=(d = Ref{Any}(nothing)) teardown=(d[] === nothing || LightXML.free(d[]); d[] = nothing)
 @add_benchmark "Parse (medium)" "XMLDict" XMLDict.xml_dict($medium_xml)
 
@@ -68,7 +76,7 @@ const SSNode = Node{SubString{String}}
 
 #-----------------------------------------------------------------------------# Read from file
 @add_benchmark "Read file" "XML.jl" read($medium_file, Node)
-@add_benchmark "Read file" "EzXML" EzXML.readxml($medium_file)
+@add_benchmark "Read file" "EzXML" (d[] = EzXML.readxml($medium_file)) setup=(d = Ref{Any}(nothing)) teardown=(d[] === nothing || finalize(d[]); d[] = nothing)
 @add_benchmark "Read file" "LightXML" (d[] = LightXML.parse_file($medium_file)) setup=(d = Ref{Any}(nothing)) teardown=(d[] === nothing || LightXML.free(d[]); d[] = nothing)
 
 #-----------------------------------------------------------------------------# Collect element tags

--- a/benchmarks/benchmarks_results.md
+++ b/benchmarks/benchmarks_results.md
@@ -2,84 +2,84 @@
 
 ```
 Parse (small)
-	XML.jl             0.0212 ms
-	XML.jl (SS)        0.0195 ms
-	EzXML              0.0132 ms  (XML.jl 60.6% slower)
-	LightXML           0.0122 ms  (XML.jl 73.1% slower)
-	XMLDict              0.11 ms  (XML.jl 80.7% faster)
+	XML.jl             0.0158 ms
+	XML.jl (SS)        0.0144 ms
+	EzXML              0.0131 ms  (XML.jl 20.4% slower)
+	LightXML           0.0114 ms  (XML.jl 38.0% slower)
+	XMLDict             0.113 ms  (XML.jl 86.1% faster)
 
 Parse (medium)
-	XML.jl               95.5 ms
-	XML.jl (SS)          90.9 ms
-	EzXML                47.3 ms  (XML.jl 102.1% slower)
-	LightXML             37.5 ms  (XML.jl 154.7% slower)
-	XMLDict             347.0 ms  (XML.jl 72.5% faster)
+	XML.jl               77.4 ms
+	XML.jl (SS)          71.0 ms
+	EzXML                46.1 ms  (XML.jl 67.8% slower)
+	LightXML             39.0 ms  (XML.jl 98.3% slower)
+	XMLDict             352.0 ms  (XML.jl 78.0% faster)
 
 Write (small)
-	XML.jl            0.00569 ms
-	EzXML             0.00572 ms  (~same)
-	LightXML           0.0583 ms  (XML.jl 90.2% faster)
+	XML.jl            0.00559 ms
+	EzXML             0.00577 ms  (~same)
+	LightXML           0.0581 ms  (XML.jl 90.4% faster)
 
 Write (medium)
-	XML.jl               25.7 ms
-	EzXML                20.7 ms  (XML.jl 24.5% slower)
-	LightXML             29.1 ms  (XML.jl 11.7% faster)
+	XML.jl               24.4 ms
+	EzXML                21.5 ms  (XML.jl 13.7% slower)
+	LightXML             28.3 ms  (XML.jl 13.8% faster)
 
 Read file
-	XML.jl               83.9 ms
-	EzXML                60.3 ms  (XML.jl 39.2% slower)
-	LightXML             39.5 ms  (XML.jl 112.3% slower)
+	XML.jl               80.5 ms
+	EzXML                59.0 ms  (XML.jl 36.3% slower)
+	LightXML             38.8 ms  (XML.jl 107.2% slower)
 
 Collect tags (small)
-	XML.jl           0.000372 ms
-	EzXML             0.00112 ms  (XML.jl 66.8% faster)
-	LightXML          0.00183 ms  (XML.jl 79.7% faster)
+	XML.jl            0.00037 ms
+	EzXML             0.00107 ms  (XML.jl 65.3% faster)
+	LightXML          0.00183 ms  (XML.jl 79.8% faster)
 
 Collect tags (medium)
-	XML.jl               4.79 ms
-	EzXML                10.4 ms  (XML.jl 54.1% faster)
-	LightXML             13.2 ms  (XML.jl 63.8% faster)
+	XML.jl               4.81 ms
+	EzXML                8.99 ms  (XML.jl 46.5% faster)
+	LightXML             13.1 ms  (XML.jl 63.3% faster)
 
 Parse SST (LazyNode)
 	XML.jl            4.96e-6 ms
-	Node (for ref)       17.5 ms  (XML.jl 100.0% faster)
+	Node (for ref)       12.5 ms  (XML.jl 100.0% faster)
 
 Parse worksheet (LazyNode)
 	XML.jl            4.96e-6 ms
-	Node (for ref)       28.5 ms  (XML.jl 100.0% faster)
+	Node (for ref)       21.3 ms  (XML.jl 100.0% faster)
 
 SST: write each <si>
-	LazyNode + write (zero-copy)     33.8 ms
-	LazyNode + write (normalize)     73.3 ms
-	Node (for ref)       5.56 ms
+	LazyNode + write (zero-copy)     22.0 ms
+	LazyNode + write (normalize)     55.3 ms
+	Node (for ref)       5.58 ms
 
 SST: unformatted text
-	LazyNode + is_simple_value     40.0 ms
-	Node (for ref)       2.38 ms
+	LazyNode + is_simple_value     24.5 ms
+	Node (for ref)       2.24 ms
 
 Worksheet: collect rows
-	children() (fresh Vector each call)     36.1 ms
-	children!(buf, n) (reused buffer)     36.5 ms
+	children() (fresh Vector each call)     24.7 ms
+	children!(buf, n) (reused buffer)     24.6 ms
 
 Worksheet: attribute scan
-	eachattribute        36.0 ms
-	attributes() (materialize dict)     36.1 ms
+	eachattribute        24.7 ms
+	attributes() (materialize dict)     25.0 ms
 
 Worksheet: single attr fetch
-	get(c, "r", "")      37.0 ms
-	attributes(c)["r"]     36.3 ms
+	get(c, "r", "")      24.8 ms
+	attributes(c)["r"]     24.7 ms
 
 Worksheet: <v> value
-	is_simple_value      36.1 ms
-	is_simple + simple_value     36.3 ms
+	is_simple_value      24.6 ms
+	is_simple + simple_value     24.9 ms
 
 XLSX sst_load! (end-to-end)
-	LazyNode             53.0 ms
-	LazyNode (entity-heavy)     49.4 ms
+	LazyNode             33.1 ms
+	LazyNode (entity-heavy)     33.2 ms
 
 XLSX cell read (end-to-end)
-	numeric ws           36.1 ms
-	string ws            33.7 ms
+	numeric ws           24.8 ms
+	string ws            22.7 ms
 
 ```
 

--- a/benchmarks/benchmarks_results.md
+++ b/benchmarks/benchmarks_results.md
@@ -2,84 +2,84 @@
 
 ```
 Parse (small)
-	XML.jl             0.0158 ms
-	XML.jl (SS)        0.0144 ms
-	EzXML              0.0131 ms  (XML.jl 20.4% slower)
-	LightXML           0.0114 ms  (XML.jl 38.0% slower)
-	XMLDict             0.113 ms  (XML.jl 86.1% faster)
+	XML.jl             0.0156 ms
+	XML.jl (SS)        0.0141 ms
+	EzXML              0.0133 ms  (XML.jl 17.2% slower)
+	LightXML           0.0112 ms  (XML.jl 38.9% slower)
+	XMLDict             0.116 ms  (XML.jl 86.5% faster)
 
 Parse (medium)
-	XML.jl               77.4 ms
-	XML.jl (SS)          71.0 ms
-	EzXML                46.1 ms  (XML.jl 67.8% slower)
-	LightXML             39.0 ms  (XML.jl 98.3% slower)
-	XMLDict             352.0 ms  (XML.jl 78.0% faster)
+	XML.jl               77.6 ms
+	XML.jl (SS)          74.6 ms
+	EzXML                46.3 ms  (XML.jl 67.7% slower)
+	LightXML             37.5 ms  (XML.jl 106.9% slower)
+	XMLDict             367.0 ms  (XML.jl 78.9% faster)
 
 Write (small)
-	XML.jl            0.00559 ms
-	EzXML             0.00577 ms  (~same)
-	LightXML           0.0581 ms  (XML.jl 90.4% faster)
+	XML.jl             0.0056 ms
+	EzXML             0.00556 ms  (~same)
+	LightXML           0.0582 ms  (XML.jl 90.4% faster)
 
 Write (medium)
-	XML.jl               24.4 ms
-	EzXML                21.5 ms  (XML.jl 13.7% slower)
-	LightXML             28.3 ms  (XML.jl 13.8% faster)
+	XML.jl               26.8 ms
+	EzXML                21.2 ms  (XML.jl 26.4% slower)
+	LightXML             30.1 ms  (XML.jl 11.0% faster)
 
 Read file
-	XML.jl               80.5 ms
-	EzXML                59.0 ms  (XML.jl 36.3% slower)
-	LightXML             38.8 ms  (XML.jl 107.2% slower)
+	XML.jl               81.9 ms
+	EzXML                58.5 ms  (XML.jl 40.1% slower)
+	LightXML             38.4 ms  (XML.jl 113.1% slower)
 
 Collect tags (small)
-	XML.jl            0.00037 ms
-	EzXML             0.00107 ms  (XML.jl 65.3% faster)
-	LightXML          0.00183 ms  (XML.jl 79.8% faster)
+	XML.jl           0.000369 ms
+	EzXML             0.00112 ms  (XML.jl 67.2% faster)
+	LightXML          0.00187 ms  (XML.jl 80.3% faster)
 
 Collect tags (medium)
-	XML.jl               4.81 ms
-	EzXML                8.99 ms  (XML.jl 46.5% faster)
-	LightXML             13.1 ms  (XML.jl 63.3% faster)
+	XML.jl               4.83 ms
+	EzXML                9.44 ms  (XML.jl 48.8% faster)
+	LightXML             14.2 ms  (XML.jl 65.9% faster)
 
 Parse SST (LazyNode)
 	XML.jl            4.96e-6 ms
-	Node (for ref)       12.5 ms  (XML.jl 100.0% faster)
+	Node (for ref)       12.2 ms  (XML.jl 100.0% faster)
 
 Parse worksheet (LazyNode)
 	XML.jl            4.96e-6 ms
-	Node (for ref)       21.3 ms  (XML.jl 100.0% faster)
+	Node (for ref)       21.9 ms  (XML.jl 100.0% faster)
 
 SST: write each <si>
-	LazyNode + write (zero-copy)     22.0 ms
-	LazyNode + write (normalize)     55.3 ms
-	Node (for ref)       5.58 ms
+	LazyNode + write (zero-copy)     22.1 ms
+	LazyNode + write (normalize)     55.0 ms
+	Node (for ref)       5.71 ms
 
 SST: unformatted text
-	LazyNode + is_simple_value     24.5 ms
-	Node (for ref)       2.24 ms
+	LazyNode + is_simple_value     25.5 ms
+	Node (for ref)       2.38 ms
 
 Worksheet: collect rows
 	children() (fresh Vector each call)     24.7 ms
-	children!(buf, n) (reused buffer)     24.6 ms
+	children!(buf, n) (reused buffer)     24.7 ms
 
 Worksheet: attribute scan
-	eachattribute        24.7 ms
-	attributes() (materialize dict)     25.0 ms
+	eachattribute        24.6 ms
+	attributes() (materialize dict)     24.7 ms
 
 Worksheet: single attr fetch
-	get(c, "r", "")      24.8 ms
+	get(c, "r", "")      24.7 ms
 	attributes(c)["r"]     24.7 ms
 
 Worksheet: <v> value
 	is_simple_value      24.6 ms
-	is_simple + simple_value     24.9 ms
+	is_simple + simple_value     24.7 ms
 
 XLSX sst_load! (end-to-end)
-	LazyNode             33.1 ms
-	LazyNode (entity-heavy)     33.2 ms
+	LazyNode             34.9 ms
+	LazyNode (entity-heavy)     35.4 ms
 
 XLSX cell read (end-to-end)
-	numeric ws           24.8 ms
-	string ws            22.7 ms
+	numeric ws           25.6 ms
+	string ws            23.3 ms
 
 ```
 

--- a/src/XMLTokenizer.jl
+++ b/src/XMLTokenizer.jl
@@ -62,23 +62,72 @@ struct Token
     ncodeunits::Int    # == SubString.ncodeunits (byte length of the token text)
 end
 
-# Emit-site constructors: take the throwaway `SubString` view a reader just built and keep
-# only its byte range. The SubString does not escape, so this allocates nothing. They keep
-# every `Token(KIND, SubString(data, a, b))` / `Token(KIND, has_amp, view)` site unchanged.
+# Convenience constructors (kept for tests): build a token from an existing `SubString`
+# view, keeping only its byte range. Scanner emit sites construct tokens directly from
+# integer scan positions via `make_token` below.
 @inline Token(kind::TokenKinds.Kind, raw::SubString) = Token(kind, false, raw.offset, raw.ncodeunits)
 @inline Token(kind::TokenKinds.Kind, has_entities::Bool, raw::SubString) =
     Token(kind, has_entities, raw.offset, raw.ncodeunits)
 
-# Recover the token's text as a zero-copy `SubString` of its source `data`. `prevind` lands
-# the end index on the START of the last character, so the round-trip is correct for
-# multibyte UTF-8 — a naive `SubString(data, off+1, off+ncu)` would pass a continuation byte
-# as the end index and throw. `_token_root` resolves `data::SubString` to its parent string
-# (token offsets are root-relative, since `SubString(::SubString, …)` flattens to the root).
+# Every span the scanner emits has both edges on UTF-8 character boundaries, so a view
+# can be rebuilt straight from the stored (offset, ncodeunits) fields with no index
+# walk. The invariant is structural: `NAME_BYTE_TABLE` classifies every byte 0x80–0xFF
+# (the UTF-8 lead/continuation bytes) as a name byte, so name scans only stop on an
+# ASCII byte or EOF, and every other span edge lands on an ASCII sentinel ('<', '>',
+# '/', quotes, '-->', ']]>', '?>') or EOF. ASCII bytes are character boundaries by
+# construction — even in malformed input. This is the package's one deliberate
+# relaxation of the "never index ± 1 on strings" rule; see issue #109.
+#
+# `SubString`'s internal `Val(:noshift)` constructor stores the two fields directly
+# (`base/strings/substring.jl:39-46` as of 1.12.6), unlike the checked constructor
+# whose unconditional `nextind` re-derives the byte length even under `@inbounds`.
+# The `@boundscheck` block preserves full validation under `--check-bounds=yes` (as in
+# `Pkg.test`); callers wrap the call in `@inbounds`, so production builds elide it.
+# If Base ever drops the constructor, the checked index-walking fallback takes over.
+if hasmethod(SubString{String}, Tuple{String, Int, Int, Val{:noshift}})
+    @inline function _noshift_substring(s::T, offset::Int, ncu::Int) where {T <: AbstractString}
+        @boundscheck begin
+            n = ncodeunits(s)
+            (0 <= offset && 0 <= ncu && offset + ncu <= n) ||
+                throw(BoundsError(s, (offset + 1):(offset + ncu)))
+            if ncu != 0
+                isvalid(s, offset + 1) || throw(StringIndexError(s, offset + 1))
+                offset + ncu == n || isvalid(s, offset + ncu + 1) ||
+                    throw(StringIndexError(s, offset + ncu + 1))
+            end
+        end
+        SubString{T}(s, offset, ncu, Val(:noshift))
+    end
+else
+    @inline function _noshift_substring(s::AbstractString, offset::Int, ncu::Int)
+        ncu == 0 && return SubString(s, 1, 0)
+        SubString(s, offset + 1, prevind(s, offset + ncu + 1))
+    end
+end
+
+# Recover the token's text as a zero-copy `SubString` of its source `data` — a direct
+# rebuild from the token's span fields (see `_noshift_substring`). `_token_root`
+# resolves `data::SubString` to its parent string (token offsets are root-relative,
+# since `SubString(::SubString, …)` flattens to the root).
 @inline _token_root(s::AbstractString) = s
 @inline _token_root(s::SubString)      = s.string
 @inline function raw(t::Token, data::AbstractString)
-    r = _token_root(data)
-    @inbounds SubString(r, t.offset + 1, prevind(r, t.offset + t.ncodeunits + 1))
+    @inbounds _noshift_substring(_token_root(data), t.offset, t.ncodeunits)
+end
+
+# Emit-side helpers. Scan positions are `data`-relative; token spans are root-relative
+# (matching what the flattening `SubString(data, i, j)` emit sites used to store), and
+# `_data_offset` bridges the two. `make_token` covers the data-relative byte range
+# [start, stop); `_span_view` is the same range as a view, for the bounded entity scan
+# on text and attribute values.
+@inline _data_offset(::AbstractString) = 0
+@inline _data_offset(s::SubString)     = s.offset
+@inline function make_token(kind::TokenKinds.Kind, has_entities::Bool, data::AbstractString,
+                            start::Int, stop::Int)
+    Token(kind, has_entities, _data_offset(data) + start - 1, stop - start)
+end
+@inline function _span_view(data::AbstractString, start::Int, stop::Int)
+    @inbounds _noshift_substring(_token_root(data), _data_offset(data) + start - 1, stop - start)
 end
 
 function Base.show(io::IO, t::Token)
@@ -106,9 +155,8 @@ struct TokenizerState
     pending::Token  # buffered token for constructs that emit two tokens at once (e.g. content + close)
 end
 
-# Create an empty token (no pending token buffered). The throwaway `SubString(s,1,0)` has
-# offset/ncodeunits 0, so the resulting Token is the (kind, false, 0, 0) sentinel.
-@inline no_token(s::AbstractString) = Token(TokenKinds.TEXT, @inbounds SubString(s, 1, 0))
+# The empty sentinel token (no pending token buffered): kind TEXT, empty span.
+@inline no_token(::AbstractString) = Token(TokenKinds.TEXT, false, 0, 0)
 # Check whether the state has a buffered pending token (the sentinel has ncodeunits 0;
 # every real pending token — COMMENT/CDATA/PI/DOCTYPE close — is non-empty).
 @inline has_pending(st::TokenizerState) = st.pending.ncodeunits != 0
@@ -255,12 +303,10 @@ end
 # O(doc_size²) on entity-free documents.
 function read_text(data::AbstractString, pos::Int)
     start = pos
-    n = ncodeunits(data)
     lt_idx = findnext('<', data, pos)
-    end_pos = isnothing(lt_idx) ? n + 1 : lt_idx
-    text = @inbounds SubString(data, start, prevind(data, end_pos))
-    has_amp = occursin('&', text)
-    tok = Token(TokenKinds.TEXT, has_amp, text)
+    end_pos = isnothing(lt_idx) ? ncodeunits(data) + 1 : lt_idx
+    has_amp = occursin('&', _span_view(data, start, end_pos))
+    tok = make_token(TokenKinds.TEXT, has_amp, data, start, end_pos)
     (tok, TokenizerState(end_pos, M_DEFAULT, no_token(data)))
 end
 
@@ -290,7 +336,7 @@ function read_bang(data::AbstractString, pos::Int, start::Int)
         pos += 1
         (!iseof(data, pos) && peek(data, pos) == UInt8('-')) || err("expected '<!--'", start)
         pos += 1
-        tok = Token(TokenKinds.COMMENT_OPEN, @inbounds SubString(data, start, pos - 1))
+        tok = make_token(TokenKinds.COMMENT_OPEN, false, data, start, pos)
         return (tok, TokenizerState(pos, M_COMMENT, no_token(data)))
     end
 
@@ -302,7 +348,7 @@ function read_bang(data::AbstractString, pos::Int, start::Int)
             peek(data, pos) == expected || err("invalid CDATA section", start)
             pos += 1
         end
-        tok = Token(TokenKinds.CDATA_OPEN, @inbounds SubString(data, start, pos - 1))
+        tok = make_token(TokenKinds.CDATA_OPEN, false, data, start, pos)
         return (tok, TokenizerState(pos, M_CDATA, no_token(data)))
     end
 
@@ -310,7 +356,7 @@ function read_bang(data::AbstractString, pos::Int, start::Int)
     @inbounds while !iseof(data, pos) && is_name_byte(peek(data, pos))
         pos += 1
     end
-    tok = Token(TokenKinds.DOCTYPE_OPEN, @inbounds SubString(data, start, pos - 1))
+    tok = make_token(TokenKinds.DOCTYPE_OPEN, false, data, start, pos)
     (tok, TokenizerState(pos, M_DOCTYPE, no_token(data)))
 end
 
@@ -328,10 +374,10 @@ function read_pi_start(data::AbstractString, pos::Int, start::Int)
         codeunit(data, name_start + 2) == UInt8('l')
 
     if is_xml
-        tok = Token(TokenKinds.XML_DECL_OPEN, @inbounds SubString(data, start, pos - 1))
+        tok = make_token(TokenKinds.XML_DECL_OPEN, false, data, start, pos)
         (tok, TokenizerState(pos, M_XML_DECL, no_token(data)))
     else
-        tok = Token(TokenKinds.PI_OPEN, @inbounds SubString(data, start, prevind(data, pos)))
+        tok = make_token(TokenKinds.PI_OPEN, false, data, start, pos)
         (tok, TokenizerState(pos, M_PI, no_token(data)))
     end
 end
@@ -342,7 +388,7 @@ function read_open_tag_start(data::AbstractString, pos::Int, start::Int)
     @inbounds while !iseof(data, pos) && is_name_byte(peek(data, pos))
         pos += 1
     end
-    tok = Token(TokenKinds.OPEN_TAG, @inbounds SubString(data, start, prevind(data, pos)))
+    tok = make_token(TokenKinds.OPEN_TAG, false, data, start, pos)
     (tok, TokenizerState(pos, M_TAG, no_token(data)))
 end
 
@@ -351,7 +397,7 @@ function read_close_tag_start(data::AbstractString, pos::Int, start::Int)
     @inbounds while !iseof(data, pos) && is_name_byte(peek(data, pos))
         pos += 1
     end
-    tok = Token(TokenKinds.CLOSE_TAG, @inbounds SubString(data, start, prevind(data, pos)))
+    tok = make_token(TokenKinds.CLOSE_TAG, false, data, start, pos)
     (tok, TokenizerState(pos, M_CLOSE_TAG, no_token(data)))
 end
 
@@ -360,7 +406,7 @@ function read_close_tag_end(data::AbstractString, pos::Int)
     pos = skip_whitespace(data, pos)
     iseof(data, pos) && err("unterminated close tag", pos)
     peek(data, pos) == UInt8('>') || err("expected '>'", pos)
-    tok = Token(TokenKinds.TAG_CLOSE, @inbounds SubString(data, pos, pos))
+    tok = make_token(TokenKinds.TAG_CLOSE, false, data, pos, pos + 1)
     (tok, TokenizerState(pos + 1, M_DEFAULT, no_token(data)))
 end
 
@@ -376,16 +422,16 @@ function read_in_tag(data::AbstractString, pos::Int, mode::Mode)
     # Check for end delimiters
     if is_decl
         if b == UInt8('?') && canpeek(data, pos, 1) && peek(data, pos + 1) == UInt8('>')
-            tok = Token(TokenKinds.XML_DECL_CLOSE, @inbounds SubString(data, pos, pos + 1))
+            tok = make_token(TokenKinds.XML_DECL_CLOSE, false, data, pos, pos + 2)
             return (tok, TokenizerState(pos + 2, M_DEFAULT, no_token(data)))
         end
     else
         if b == UInt8('>')
-            tok = Token(TokenKinds.TAG_CLOSE, @inbounds SubString(data, pos, pos))
+            tok = make_token(TokenKinds.TAG_CLOSE, false, data, pos, pos + 1)
             return (tok, TokenizerState(pos + 1, M_DEFAULT, no_token(data)))
         end
         if b == UInt8('/') && canpeek(data, pos, 1) && peek(data, pos + 1) == UInt8('>')
-            tok = Token(TokenKinds.SELF_CLOSE, @inbounds SubString(data, pos, pos + 1))
+            tok = make_token(TokenKinds.SELF_CLOSE, false, data, pos, pos + 2)
             return (tok, TokenizerState(pos + 2, M_DEFAULT, no_token(data)))
         end
     end
@@ -395,8 +441,8 @@ function read_in_tag(data::AbstractString, pos::Int, mode::Mode)
     @inbounds while !iseof(data, pos) && is_name_byte(peek(data, pos))
         pos += 1
     end
-    name_end = prevind(data, pos)
-    name_start > name_end && err("expected attribute name or tag close", pos)
+    name_stop = pos
+    name_start == name_stop && err("expected attribute name or tag close", pos)
 
     # Consume '=' and surrounding whitespace (not part of any token)
     pos = skip_whitespace(data, pos)
@@ -405,7 +451,7 @@ function read_in_tag(data::AbstractString, pos::Int, mode::Mode)
     pos = skip_whitespace(data, pos)
 
     next_state = is_decl ? M_XML_DECL_VALUE : M_TAG_VALUE
-    tok = Token(TokenKinds.ATTR_NAME, @inbounds SubString(data, name_start, name_end))
+    tok = make_token(TokenKinds.ATTR_NAME, false, data, name_start, name_stop)
     (tok, TokenizerState(pos, next_state, no_token(data)))
 end
 
@@ -424,13 +470,11 @@ function read_attr_value(data::AbstractString, pos::Int, mode::Mode)
     close_idx = findnext(quote_char, data, pos)
     isnothing(close_idx) && err("unterminated attribute value", start)
     # Value range is [pos, close_idx - 1]; entity check is bounded to this view.
-    inner = @inbounds SubString(data, pos, prevind(data, close_idx))
-    has_amp = occursin('&', inner)
+    has_amp = occursin('&', _span_view(data, pos, close_idx))
     pos = close_idx + 1  # one past the closing quote (always ASCII)
 
     next_state = (mode == M_XML_DECL_VALUE) ? M_XML_DECL : M_TAG
-    valraw = @inbounds SubString(data, start, pos - 1)
-    tok = Token(TokenKinds.ATTR_VALUE, has_amp, valraw)
+    tok = make_token(TokenKinds.ATTR_VALUE, has_amp, data, start, pos)
     (tok, TokenizerState(pos, next_state, no_token(data)))
 end
 
@@ -442,12 +486,10 @@ function read_comment_body(data::AbstractString, pos::Int)
         if peek(data, pos) == UInt8('-') &&
            canpeek(data, pos, 1) && peek(data, pos + 1) == UInt8('-') &&
            canpeek(data, pos, 2) && peek(data, pos + 2) == UInt8('>')
-            content_end = prevind(data, pos)
-            close_start = pos
-            pos += 3
-            pending = Token(TokenKinds.COMMENT_CLOSE, SubString(data, close_start, pos - 1))
-            tok = Token(TokenKinds.COMMENT_CONTENT, SubString(data, start, content_end))
-            return (tok, TokenizerState(pos, M_DEFAULT, pending))
+            close_stop = pos + 3
+            pending = make_token(TokenKinds.COMMENT_CLOSE, false, data, pos, close_stop)
+            tok = make_token(TokenKinds.COMMENT_CONTENT, false, data, start, pos)
+            return (tok, TokenizerState(close_stop, M_DEFAULT, pending))
         end
         pos += 1
     end
@@ -461,12 +503,10 @@ function read_cdata_body(data::AbstractString, pos::Int)
         if peek(data, pos) == UInt8(']') &&
            canpeek(data, pos, 1) && peek(data, pos + 1) == UInt8(']') &&
            canpeek(data, pos, 2) && peek(data, pos + 2) == UInt8('>')
-            content_end = prevind(data, pos)
-            close_start = pos
-            pos += 3
-            pending = Token(TokenKinds.CDATA_CLOSE, SubString(data, close_start, pos - 1))
-            tok = Token(TokenKinds.CDATA_CONTENT, SubString(data, start, content_end))
-            return (tok, TokenizerState(pos, M_DEFAULT, pending))
+            close_stop = pos + 3
+            pending = make_token(TokenKinds.CDATA_CLOSE, false, data, pos, close_stop)
+            tok = make_token(TokenKinds.CDATA_CONTENT, false, data, start, pos)
+            return (tok, TokenizerState(close_stop, M_DEFAULT, pending))
         end
         pos += 1
     end
@@ -478,12 +518,10 @@ function read_pi_body(data::AbstractString, pos::Int)
     start = pos
     @inbounds while !iseof(data, pos)
         if peek(data, pos) == UInt8('?') && canpeek(data, pos, 1) && peek(data, pos + 1) == UInt8('>')
-            content_end = prevind(data, pos)
-            close_start = pos
-            pos += 2
-            pending = Token(TokenKinds.PI_CLOSE, SubString(data, close_start, pos - 1))
-            tok = Token(TokenKinds.PI_CONTENT, SubString(data, start, content_end))
-            return (tok, TokenizerState(pos, M_DEFAULT, pending))
+            close_stop = pos + 2
+            pending = make_token(TokenKinds.PI_CLOSE, false, data, pos, close_stop)
+            tok = make_token(TokenKinds.PI_CONTENT, false, data, start, pos)
+            return (tok, TokenizerState(close_stop, M_DEFAULT, pending))
         end
         pos += 1
     end
@@ -519,12 +557,10 @@ function read_doctype_body(data::AbstractString, pos::Int)
             depth -= 1
             pos += 1
         elseif b == UInt8('>') && depth == 0
-            content_end = prevind(data, pos)
-            close_start = pos
-            pos += 1
-            pending = Token(TokenKinds.DOCTYPE_CLOSE, @inbounds SubString(data, close_start, pos - 1))
-            tok = Token(TokenKinds.DOCTYPE_CONTENT, @inbounds SubString(data, start, content_end))
-            return (tok, TokenizerState(pos, M_DEFAULT, pending))
+            close_stop = pos + 1
+            pending = make_token(TokenKinds.DOCTYPE_CLOSE, false, data, pos, close_stop)
+            tok = make_token(TokenKinds.DOCTYPE_CONTENT, false, data, start, pos)
+            return (tok, TokenizerState(close_stop, M_DEFAULT, pending))
         else
             pos += 1
         end
@@ -612,11 +648,11 @@ Extract the element name from an `OPEN_TAG` or `CLOSE_TAG` token. `data` is the 
 token was scanned from (needed to recover the text — see [`raw`](@ref)).
 """
 function tag_name(token::Token, data)
-    r = raw(token, data)
+    r = _token_root(data)
     if token.kind == TokenKinds.OPEN_TAG
-        @inbounds SubString(r, 2, lastindex(r))  # skip '<'; lastindex (not ncodeunits) for multibyte names
+        @inbounds _noshift_substring(r, token.offset + 1, token.ncodeunits - 1)  # skip '<'
     elseif token.kind == TokenKinds.CLOSE_TAG
-        @inbounds SubString(r, 3, lastindex(r))  # skip '</'
+        @inbounds _noshift_substring(r, token.offset + 2, token.ncodeunits - 2)  # skip '</'
     else
         throw(ArgumentError("tag_name requires OPEN_TAG or CLOSE_TAG, got $(token.kind)"))
     end
@@ -630,8 +666,9 @@ Strip the surrounding quotes from an `ATTR_VALUE` token. `data` is the source st
 function attr_value(token::Token, data)
     token.kind == TokenKinds.ATTR_VALUE ||
         throw(ArgumentError("attr_value requires ATTR_VALUE, got $(token.kind)"))
-    r = raw(token, data)
-    @inbounds SubString(r, 2, prevind(r, lastindex(r)))
+    # Strip the quotes by span arithmetic — quotes are ASCII, so both edges stay on
+    # character boundaries.
+    @inbounds _noshift_substring(_token_root(data), token.offset + 1, token.ncodeunits - 2)
 end
 
 """
@@ -642,8 +679,7 @@ Extract the target name from a `PI_OPEN` or `XML_DECL_OPEN` token. `data` is the
 function pi_target(token::Token, data)
     (token.kind == TokenKinds.PI_OPEN || token.kind == TokenKinds.XML_DECL_OPEN) ||
         throw(ArgumentError("pi_target requires PI_OPEN or XML_DECL_OPEN, got $(token.kind)"))
-    r = raw(token, data)
-    @inbounds SubString(r, 3, lastindex(r))  # skip '<?'
+    @inbounds _noshift_substring(_token_root(data), token.offset + 2, token.ncodeunits - 2)  # skip '<?'
 end
 
 end # module XMLTokenizer

--- a/test/test_tokenizer.jl
+++ b/test/test_tokenizer.jl
@@ -484,6 +484,20 @@ end
     end
 end
 
+@testset "Token convenience constructors mirror SubString fields" begin
+    xml = "<a>té</a>"
+    sub = SubString(xml, 4, 5)          # "té" — ends on a 2-byte character
+    t1 = Token(TokenKinds.TEXT, sub)
+    t2 = Token(TokenKinds.TEXT, true, sub)
+    @test (t1.offset, t1.ncodeunits) == (sub.offset, ncodeunits(sub))
+    @test (t2.offset, t2.ncodeunits) == (sub.offset, ncodeunits(sub))
+    @test !t1.has_entities
+    @test t2.has_entities
+    @test raw(t1, xml) == "té" == raw(t2, xml)
+    # Direct, non-inlined call takes the @boundscheck-validated construction path.
+    @test XML.XMLTokenizer._noshift_substring(xml, t1.offset, t1.ncodeunits) == "té"
+end
+
 #-----------------------------------------------------------------------# Edge cases
 @testset "adjacent tags" begin
     xml = "<a></a><b></b>"

--- a/test/test_tokenizer.jl
+++ b/test/test_tokenizer.jl
@@ -9,6 +9,29 @@ using XML.XMLTokenizer: tokenize, TokenKinds, Token, tag_name, attr_value, pi_ta
 kinds(xml) = [t.kind for t in tokenize(xml)]
 raws(xml)  = [String(raw(t, xml)) for t in tokenize(xml)]
 
+# Multibyte torture document: 2-, 3-, and 4-byte UTF-8 in element names, attribute
+# names/values, text, comment, CDATA, PI content and DOCTYPE body, plus an empty
+# attribute value and entity-bearing text. Used by the span-equivalence sweeps below.
+const MULTIBYTE_DOC = """
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE café [ <!-- déjà-vu --> ]>
+<café idée="héllo wörld" 名前="日本語テキスト" emoji="🎈🎉" vide="">
+  texte accentué été 🎯 &amp; fin
+  <日本語 attr='単一引用符'>中身テキスト</日本語>
+  <!-- commentaire évênement 🚀 -->
+  <![CDATA[données brutes ]] presque-fin 💾]]>
+  <?traitement instruction ciblée 🛰?>
+  <vide/>
+</café>
+"""
+
+# Reference reconstruction of a token's byte span [off+1, off+ncu] through Julia's
+# checked, index-walking SubString path (empty spans reconstruct as ""). The accessors
+# must agree with this on every token — proving the tokenizer's span arithmetic
+# equivalent to checked string slicing, multibyte and empty spans included (issue #109).
+checked_span(xml, off, ncu) =
+    ncu == 0 ? SubString(xml, 1, 0) : SubString(xml, off + 1, prevind(xml, off + ncu + 1))
+
 @testset "XMLTokenizer" begin
 
 #-----------------------------------------------------------------------# Basic text
@@ -365,6 +388,100 @@ end
     xml = "<!-- héllo -->"
     toks = collect(tokenize(xml))
     @test raw(toks[2], xml) == " héllo "
+end
+
+@testset "multibyte element names" begin
+    xml = "<café>x</café  ><日本語/><t🎈/>"
+    toks = collect(tokenize(xml))
+    opens  = [tag_name(t, xml) for t in toks if t.kind == TokenKinds.OPEN_TAG]
+    closes = [tag_name(t, xml) for t in toks if t.kind == TokenKinds.CLOSE_TAG]
+    @test opens  == ["café", "日本語", "t🎈"]
+    @test closes == ["café"]
+end
+
+@testset "multibyte attribute names and values" begin
+    xml = """<x 名前="日本語テキスト" emoji="🎈🎉" idée='héllo wörld' vide=""/>"""
+    names = [String(raw(t, xml)) for t in tokenize(xml) if t.kind == TokenKinds.ATTR_NAME]
+    vals  = [String(attr_value(t, xml)) for t in tokenize(xml) if t.kind == TokenKinds.ATTR_VALUE]
+    @test names == ["名前", "emoji", "idée", "vide"]
+    @test vals  == ["日本語テキスト", "🎈🎉", "héllo wörld", ""]
+end
+
+@testset "multibyte immediately before a delimiter" begin
+    # The span's end boundary lands right after a 2-/3-/4-byte character in every reader
+    # that stops on an ASCII sentinel ('<', quotes, '-->', ']]>', '?>', '>').
+    xml = "<!--déjà-->"
+    @test raw(collect(tokenize(xml))[2], xml) == "déjà"
+    xml = "<![CDATA[日]]>"
+    @test raw(collect(tokenize(xml))[2], xml) == "日"
+    xml = "<?p ciblée 🛰?>"
+    @test raw(collect(tokenize(xml))[2], xml) == " ciblée 🛰"
+    xml = "<a>été</a>"
+    @test raw(collect(tokenize(xml))[3], xml) == "été"
+    xml = "<!DOCTYPE ré>"
+    @test raw(collect(tokenize(xml))[2], xml) == " ré"
+    xml = """<x a="é">"""
+    @test attr_value(collect(tokenize(xml))[3], xml) == "é"
+end
+
+@testset "PI with multibyte target" begin
+    xml = "<?ciblé données?>"
+    toks = collect(tokenize(xml))
+    @test pi_target(toks[1], xml) == "ciblé"
+    @test raw(toks[2], xml) == " données"
+end
+
+#-----------------------------------------------------------------------# Span equivalence
+@testset "accessors match checked span reconstruction" begin
+    for xml in (
+        MULTIBYTE_DOC,
+        "<r a=\"1\"><c>text</c><!-- x --><![CDATA[d]]><?pi p?><e/></r>",
+    )
+        for t in tokenize(xml)
+            r = raw(t, xml)
+            @test r isa SubString{String}
+            @test r == checked_span(xml, t.offset, t.ncodeunits)
+            if t.kind == TokenKinds.OPEN_TAG
+                @test tag_name(t, xml) == checked_span(xml, t.offset + 1, t.ncodeunits - 1)
+            elseif t.kind == TokenKinds.CLOSE_TAG
+                @test tag_name(t, xml) == checked_span(xml, t.offset + 2, t.ncodeunits - 2)
+            elseif t.kind == TokenKinds.ATTR_VALUE
+                @test attr_value(t, xml) == checked_span(xml, t.offset + 1, t.ncodeunits - 2)
+            elseif t.kind == TokenKinds.PI_OPEN || t.kind == TokenKinds.XML_DECL_OPEN
+                @test pi_target(t, xml) == checked_span(xml, t.offset + 2, t.ncodeunits - 2)
+            end
+            if t.kind == TokenKinds.TEXT || t.kind == TokenKinds.ATTR_VALUE
+                @test t.has_entities == occursin('&', r)
+            end
+        end
+    end
+end
+
+@testset "token spans are root-relative for SubString input" begin
+    # `SubString(::SubString, …)` flattens to the root string, so tokens scanned from a
+    # SubString carry root-relative offsets; `raw` resolves the root the same way.
+    padded = "x" * MULTIBYTE_DOC * "y"
+    sub = SubString(padded, 2, prevind(padded, lastindex(padded)))
+    @test sub == MULTIBYTE_DOC
+    @test length(collect(tokenize(sub))) == length(collect(tokenize(MULTIBYTE_DOC)))
+    for (t, tref) in zip(tokenize(sub), tokenize(MULTIBYTE_DOC))
+        @test t.kind == tref.kind
+        @test raw(t, sub) == raw(tref, MULTIBYTE_DOC)
+        @test raw(t, sub) == checked_span(padded, t.offset, t.ncodeunits)
+    end
+end
+
+@testset "empty spans reconstruct as empty strings" begin
+    for (xml, k) in (
+        ("<!---->", TokenKinds.COMMENT_CONTENT),
+        ("<![CDATA[]]>", TokenKinds.CDATA_CONTENT),
+        ("<?t?>", TokenKinds.PI_CONTENT),
+    )
+        t = only(tok for tok in tokenize(xml) if tok.kind == k)
+        @test t.ncodeunits == 0
+        @test isempty(raw(t, xml))
+        @test raw(t, xml) == ""
+    end
 end
 
 #-----------------------------------------------------------------------# Edge cases


### PR DESCRIPTION
Closes #109.

Tokens now carry byte spans end to end. Emit sites build `Token`s directly from the integer scan positions already in hand, and `raw()`/`tag_name`/`attr_value`/`pi_target` rebuild their views straight from the stored `(offset, ncodeunits)` fields — no `prevind`/`nextind` walks, no checked-constructor length recomputation. The soundness argument is the one from #109: a DFA lexer over UTF-8 stops only on ASCII structural bytes (`NAME_BYTE_TABLE` classifies 0x80–0xFF as name bytes), so every span edge is a character boundary by construction, even on malformed input; the invariant is documented at the point of reliance, and a `@boundscheck` block keeps full validation active under `--check-bounds=yes`, so `Pkg.test` verifies every span the suite builds. Public behavior is unchanged: `raw` and the accessors still return `SubString{String}`, and `Token` stays isbits.

BenchmarkTools `@benchmark` medians at default parameters, 14 MB XMark corpus, same-session A/B (A = `f6e1017`); external witness cells (EzXML, LightXML, walks/extracts on already-built trees) within ±2 %:

| Cell | main | this PR | Δ |
|---|--:|--:|--:|
| lex only (tokenize, no tree) | 37.4 ms | 25.6 ms | **−32 %** |
| parse → DOM (`Node`) | 103.3 ms (GC 23.0) | 74.7 ms (GC 17.7) | **−28 %** |
| build `FlatNode` | 53.4 ms | 34.9 ms | **−35 %** |
| `Cursor` full stream (tag+value reads) | 46.3 ms | 30.6 ms | **−34 %** |
| `LazyNode` full walk | 290.6 ms | 184.9 ms | **−36 %** |
| full extract, `Node` `String` / `SubString` | 103.7 / 98.2 ms | 82.3 / 72.8 ms | **−21 / −26 %** |

Allocations, retained sizes and node counts are identical on every cell — the removed round-trips were index arithmetic on stack-allocated views, not heap traffic, so the gain is pure CPU. Two cross-library claims flip and the docs now say so: `FlatNode` out-builds libxml2 (34.9 vs 45.8 ms, ~1.3×), and the pure-Julia `Cursor` streams ~2× ahead of EzXML's `StreamReader` (30.6 vs 66.4 ms).

Tests went in first (`8c72293`): the tokenizer testset grows to 469 assertions — every accessor pinned against a checked index-walking reconstruction of its span (still meaningful after the switch: it proves the fast path equal to checked semantics), multibyte coverage with 2-/3-/4-byte characters across names, attribute names/values, text, CDATA and PI content, root-relative spans for `SubString` input, empty spans, and the `has_entities` flag. `Pkg.test`: 3981/3981, with `--check-bounds=yes` exercising the validation path on every token the suite builds; W3C not-wf verdicts identical on all 1257 documents; a per-token equivalence probe over the corpus reports 1,850,962 tokens, zero mismatches.

Docs re-measured in this PR on the unchanged protocol: PERFORMANCE-v0.4.md Tables 1–4 (the two flipped claims re-worded), the README access-pattern and cross-library tables (sub-millisecond rows now quoted in µs), and CHANGELOG entries under Unreleased/Changed.

One suite fix rides along: `benchmarks/benchmarks.jl` now bounds its own C heap — the medium/read-file EzXML cells free their C tree per sample (untimed `finalize` teardown, mirroring the existing LightXML pattern; cell timings verified unchanged across four same-day runs, EzXML medium stable at 46.1–46.3 ms), and `@add_benchmark` collects between cells so finalizer-held residue never crosses a cell boundary. A full suite run used to page the machine several GB deep; XMLDict is deliberately left without a per-sample teardown so the GC cost its allocation-heavy conversion pays in real use stays in its number.