### PR TITLE
Elide the noshift constructor's internal bounds walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   full suite run no longer pages the machine. Sub-millisecond rows of the README table
   are now quoted in microseconds (#110).
 
+- **The span-native fast path now truly elides every validation walk**: `@inbounds`
+  elision reaches one inlining level and applies only to callees that actually inline —
+  Base's `Val(:noshift)` constructor did neither, so every view construction still paid
+  its internal `prevind` plus two `isvalid` under production flags. The constructor call
+  now carries `@inbounds` plus a callsite `@inline`; `--check-bounds=yes` (as in
+  `Pkg.test`) still validates every span the suite builds. On the 14 MB benchmark corpus:
+  lex −7 %, `Node` build −10 %, `FlatNode` build −19 % (now ~1.7× ahead of libxml2),
+  `Cursor` full stream −12 %, `LazyNode` full walk −8 %; allocations unchanged (#111).
+
 ## [0.4.4] - 2026-07-31
 
 ### Added

--- a/PERFORMANCE-v0.4.md
+++ b/PERFORMANCE-v0.4.md
@@ -4,7 +4,7 @@ The headline cross-library figures live in the [README](README.md#benchmarks). T
 
 ## The theory behind "optimal"
 
-XML parsing splits into two language-theory levels, and v0.4 hits the **asymptotic lower bound** of each — the sense in which the lexer and parser are "optimal". The gap to a C library like [libxml2](https://en.wikipedia.org/wiki/Libxml2) is constant-factor (C tuning, a leaner non-Julia-heap tree), not asymptotic — and only on the pointer-tree `Node` build; `FlatNode` now out-builds libxml2 (Table 4), and at streaming XML.jl is ~2× *faster* (Table 1).
+XML parsing splits into two language-theory levels, and v0.4 hits the **asymptotic lower bound** of each — the sense in which the lexer and parser are "optimal". The gap to a C library like [libxml2](https://en.wikipedia.org/wiki/Libxml2) is constant-factor (C tuning, a leaner non-Julia-heap tree), not asymptotic — and only on the pointer-tree `Node` build; `FlatNode` now out-builds libxml2 (Table 4), and at streaming XML.jl is ~2.5× *faster* (Table 1).
 
 ### Level 1 — lexing is finite-state
 
@@ -51,8 +51,8 @@ untouched; EzXML's `StreamReader` is libxml2's reader, paying FFI per event:
 
 | Stream | time (incl. GC) | memory |
 |---|--:|--:|
-| **XML.jl `Cursor`** | **31 ms** | **0.0 MiB** |
-| EzXML `StreamReader` | 66 ms (GC 0.9) | 36 MiB |
+| **XML.jl `Cursor`** | **26 ms** | **0.0 MiB** |
+| EzXML `StreamReader` | 71 ms (GC 0.6) | 36 MiB |
 
 _Table 1 — streaming: events only, no tree built._[^profile]
 
@@ -81,10 +81,10 @@ libxml2 wins the build; XML.jl materialises an 882 K-node Julia tree, EzXML a le
 
 | Full DOM extract | time (incl. GC) | memory |
 |---|--:|--:|
-| EzXML (libxml2) | **61 ms** | **54 MiB** |
-| LightXML (elements only) | 63 ms (GC 1.4) | 57 MiB |
-| XML.jl (`SubString`, zero-copy) | 73 ms (GC 17) | 95 MiB |
-| XML.jl (`String`) | 82 ms (GC 20) | 100 MiB |
+| EzXML (libxml2) | **60 ms** | **54 MiB** |
+| LightXML (elements only) | 65 ms (GC 1.4) | 57 MiB |
+| XML.jl (`SubString`, zero-copy) | 79 ms (GC 30) | 95 MiB |
+| XML.jl (`String`) | 79 ms (GC 25) | 100 MiB |
 | XML.jl **v0.3.9** (previous release) | 530 ms | 1422 MiB |
 
 _Table 2 — full-DOM extraction (parse + pull every tag/text), cross-library._[^profile]
@@ -94,9 +94,9 @@ _Table 2 — full-DOM extraction (parse + pull every tag/text), cross-library._[
 | Stage | time (incl. GC) | allocated |
 |---|--:|--:|
 | read file (I/O) | 0.6 ms | — |
-| **lex — the DFA** | **25.6 ms** | **0 B** |
-| parse → DOM (lex + build the tree, the VPA) | 74.7 ms (GC 18) | 100 MiB |
-| traverse a built tree | 4.1 ms | 0 B |
+| **lex — the DFA** | **23.4 ms** | **0 B** |
+| parse → DOM (lex + build the tree, the VPA) | 62.5 ms (GC 13) | 100 MiB |
+| traverse a built tree | 4.2 ms | 0 B |
 
 _Table 3 — the XML.jl pipeline, decomposed (`String` variant)._[^profile]
 
@@ -118,17 +118,17 @@ Measured on the same XMark document:
 
 | Full DOM, per reader | build (incl. GC) | walk every node | extract all values | DOM size in memory |
 |---|--:|--:|--:|--:|
-| **`FlatNode`** | **34.9 ms (GC 0.1)** | **2.96 ms** | 6.6 ms | **54.9 MiB** |
-| `Node` | 81.1 ms (GC 23) | 3.49 ms | **3.6 ms** | 71.6 MiB |
-| EzXML (libxml2) | 45.8 ms | — | — | — |
+| **`FlatNode`** | **28.3 ms (GC 0.1)** | **2.97 ms** | 6.5 ms | **54.9 MiB** |
+| `Node` | 72.9 ms (GC 23) | 3.34 ms | **3.6 ms** | 71.6 MiB |
+| EzXML (libxml2) | 47.2 ms | — | — | — |
 
 _Table 4 — per-reader full-DOM comparison; *build* is the whole `parse` call, and *DOM size* is the **retained** live tree (`Base.summarysize`), not allocations._[^flatbench]
 
-Build allocations: 42.2 MiB (`FlatNode`) vs 99.8 MiB (`Node` — down from 122.3 MiB before the scratch-stack build), and the *build* ranking now puts `FlatNode` ahead of libxml2 itself (~1.3× faster; `Node` remains ~1.8× behind the C library). The GC cells say why `FlatNode` builds so cheaply: its build allocates a handful of arrays instead of 882 K objects, so its median GC share is ~0.1 ms where `Node`'s is ~23 ms. Access on the finished stores: whole-tree walks are close (2.96 vs 3.49 ms — exact-size children vectors keep `Node`'s locality sharp), `parent`/`depth` stay O(1) index hops on `FlatNode` where `Node` must search down from the root, and pure value extraction on an already-built tree is the pattern where `Node`'s direct field reads win outright (3.6 vs 6.6 ms, ~1.8× — a computed `SubString` view per value is the flat store's toll).
+Build allocations: 42.2 MiB (`FlatNode`) vs 99.8 MiB (`Node` — down from 122.3 MiB before the scratch-stack build), and the *build* ranking now puts `FlatNode` ahead of libxml2 itself (~1.7× faster; `Node` remains ~1.5× behind the C library). The GC cells say why `FlatNode` builds so cheaply: its build allocates a handful of arrays instead of 882 K objects, so its median GC share is ~0.1 ms where `Node`'s is ~23 ms. Access on the finished stores: whole-tree walks are close (2.97 vs 3.34 ms — exact-size children vectors keep `Node`'s locality sharp), `parent`/`depth` stay O(1) index hops on `FlatNode` where `Node` must search down from the root, and pure value extraction on an already-built tree is the pattern where `Node`'s direct field reads win outright (3.6 vs 6.5 ms, ~1.8× — a computed `SubString` view per value is the flat store's toll).
 
 ### Choosing
 
-Stream / low-memory / read-only full-DOM / repeated traversal → **XML.jl**; `FlatNode` now out-builds the libxml2 binder (~1.3×: 34.9 vs 45.8 ms), and the C library's remaining win is the one-shot *`Node`* build-and-extract (~1.2–1.4× end-to-end, Table 2) — either way, pure Julia, no C dependency. Against its own past, v0.4 is **~5× faster and ~12× leaner than 0.3.9** (which used ~1.4 GiB for this file) — see [`benchmarks/profile.jl`](benchmarks/profile.jl), [`benchmarks/profile_vs_039.jl`](benchmarks/profile_vs_039.jl), [`benchmarks/compare.jl`](benchmarks/compare.jl).
+Stream / low-memory / read-only full-DOM / repeated traversal → **XML.jl**; `FlatNode` now out-builds the libxml2 binder (~1.7×: 28.3 vs 47.2 ms), and the C library's remaining win is the one-shot *`Node`* build-and-extract (~1.3× end-to-end, Table 2) — either way, pure Julia, no C dependency. Against its own past, v0.4 is **~5× faster and ~12× leaner than 0.3.9** (which used ~1.4 GiB for this file) — see [`benchmarks/profile.jl`](benchmarks/profile.jl), [`benchmarks/profile_vs_039.jl`](benchmarks/profile_vs_039.jl), [`benchmarks/compare.jl`](benchmarks/compare.jl).
 
 > [!NOTE]
 > **`:strict`** adds a character-range scan over text (a second O(content) pass); the overhead scales with the document's *text share* — ~1.1× on the markup-heavy XMark corpus, up to ~20× on a pure-text document; `:lenient` / `:structural` are unaffected.
@@ -144,6 +144,6 @@ Stream / low-memory / read-only full-DOM / repeated traversal → **XML.jl**; `F
 > computation. It trims GC pauses, not the materialization floor: the build's GC-free work
 > is unchanged.
 
-[^profile]: Tables 1–3: measured 2026-08-03 (the `v0.3.9` row: 2026-06-28), Apple M5 (single-threaded), Julia 1.12.6; EzXML 1.2.3 / LightXML 0.9.3 (libxml2 2.15.3); BenchmarkTools at a 5 s budget per cell. Source: [`benchmarks/profile.jl`](benchmarks/profile.jl).
+[^profile]: Tables 1–3: measured 2026-08-04 (the `v0.3.9` row: 2026-06-28), Apple M5 (single-threaded), Julia 1.12.6; EzXML 1.2.3 / LightXML 0.9.3 (libxml2 2.15.3); BenchmarkTools at a 5 s budget per cell. Source: [`benchmarks/profile.jl`](benchmarks/profile.jl).
 
-[^flatbench]: Table 4 (and the README access-pattern table): measured 2026-08-03, same machine, Julia and BenchmarkTools settings; source [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl).
+[^flatbench]: Table 4 (and the README access-pattern table): measured 2026-08-04, same machine, Julia and BenchmarkTools settings; source [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl).

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ doc = read("file.xml", LazyNode)
 
 `LazyNode` supports the same read-only interface as `Node`: `nodetype`, `tag`, `attributes`, `value`, `children`, `is_simple`, `simple_value`, plus integer and string indexing.
 
-`LazyNode` is for *partial* reads only: opening is a no-op wrapper (~0.5 µs whatever the file size), a traversal pays only for the bytes it steps over — descending to a target is O(bytes before it), so reaching this 14 MB file's root element costs ~4 µs — and nothing is cached, so repeated visits pay again. Unbeatable for descents and kilobyte-scale documents; for whole-tree walks (185 ms vs ~38/~85 ms build+walk on the 14 MB corpus below) and repeated queries, build `FlatNode` or `Node` instead — see [Performance by access pattern](#performance-by-access-pattern).
+`LazyNode` is for *partial* reads only: opening is a no-op wrapper (~0.5 µs whatever the file size), a traversal pays only for the bytes it steps over — descending to a target is O(bytes before it), so reaching this 14 MB file's root element costs ~4 µs — and nothing is cached, so repeated visits pay again. Unbeatable for descents and kilobyte-scale documents; for whole-tree walks (171 ms vs ~31/~76 ms build+walk on the 14 MB corpus below) and repeated queries, build `FlatNode` or `Node` instead — see [Performance by access pattern](#performance-by-access-pattern).
 
 For streaming and high-throughput workloads, several extra accessors avoid materializing intermediate collections:
 
@@ -337,15 +337,15 @@ One number cannot rank the readers — cost depends on what you do with the docu
 
 | | build | walk every node | extract all values | DOM size in memory |
 |---|--:|--:|--:|--:|
-| `Cursor` | — (streams) | 25.3 ms (its one scan) | — | — (no DOM) |
-| `LazyNode` | ~0 (a wrapper) | 185 ms (re-tokenizes) | — | — (source only) |
-| `FlatNode` | 34.9 ms | 2.96 ms | 6.6 ms | 54.9 MiB |
-| `Node` | 81.1 ms | 3.49 ms | 3.6 ms | 71.6 MiB |
-| EzXML (libxml2) | 45.8 ms | — | — | — |
+| `Cursor` | — (streams) | 23.1 ms (its one scan) | — | — (no DOM) |
+| `LazyNode` | ~0 (a wrapper) | 171 ms (re-tokenizes) | — | — (source only) |
+| `FlatNode` | 28.3 ms | 2.97 ms | 6.5 ms | 54.9 MiB |
+| `Node` | 72.9 ms | 3.34 ms | 3.6 ms | 71.6 MiB |
+| EzXML (libxml2) | 47.2 ms | — | — | — |
 
-Reading the table: `Cursor`'s walk *is* its parse — one tokenizing scan, nothing retained. `LazyNode` opens for free and pays per node visited — unbeatable for touching a *fraction* of a large document, and (as the walk column shows) the wrong tool for visiting all of it. `FlatNode` builds ~2.3× faster than `Node`, holds ~23% less memory, and its `parent`/`depth` are O(1) where `Node` searches from the root; whole-tree walks are close (`Node`'s exact-size children vectors keep its locality sharp), and pure value extraction on an already-built tree is the one pattern where `Node`'s direct fields win outright, by ~1.8×. `FlatNode` now out-builds even libxml2 (~1.3×), and `Node`'s remaining gap to the C library is materialization, not scanning (see [PERFORMANCE-v0.4.md](PERFORMANCE-v0.4.md)).
+Reading the table: `Cursor`'s walk *is* its parse — one tokenizing scan, nothing retained. `LazyNode` opens for free and pays per node visited — unbeatable for touching a *fraction* of a large document, and (as the walk column shows) the wrong tool for visiting all of it. `FlatNode` builds ~2.6× faster than `Node`, holds ~23% less memory, and its `parent`/`depth` are O(1) where `Node` searches from the root; whole-tree walks are close (`Node`'s exact-size children vectors keep its locality sharp), and pure value extraction on an already-built tree is the one pattern where `Node`'s direct fields win outright, by ~1.8×. `FlatNode` now out-builds even libxml2 (~1.7×), and `Node`'s remaining gap to the C library is materialization, not scanning (see [PERFORMANCE-v0.4.md](PERFORMANCE-v0.4.md)).
 
-_Measured 2026-08-03, Apple M5 (single-threaded), Julia 1.12.6, EzXML 1.2.3; BenchmarkTools medians._
+_Measured 2026-08-04, Apple M5 (single-threaded), Julia 1.12.6, EzXML 1.2.3; BenchmarkTools medians._
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -355,12 +355,12 @@ Source: [`benchmarks/benchmarks.jl`](benchmarks/benchmarks.jl). Data: `books.xml
 
 | Benchmark | XML.jl | EzXML | LightXML | XMLDict |
 |---|--:|--:|--:|--:|
-| Parse, small | 15.6 µs | 13.3 µs | 11.2 µs | 116 µs |
-| Parse, medium | 77.6 ms | 46.3 ms | 37.5 ms | 367 ms |
-| Write, small | 5.60 µs | 5.56 µs | 58.2 µs | — |
-| Write, medium | 26.8 ms | 21.2 ms | 30.1 ms | — |
-| Collect tags, small | 0.37 µs | 1.12 µs | 1.87 µs | — |
-| Collect tags, medium | 4.83 ms | 9.44 ms | 14.2 ms | — |
+| Parse, small | 13.2 µs | 12.6 µs | 11.8 µs | 111 µs |
+| Parse, medium | 70.0 ms | 46.3 ms | 36.8 ms | 353 ms |
+| Write, small | 5.59 µs | 5.78 µs | 57.6 µs | — |
+| Write, medium | 24.5 ms | 21.3 ms | 30.1 ms | — |
+| Collect tags, small | 0.37 µs | 1.15 µs | 1.85 µs | — |
+| Collect tags, medium | 4.79 ms | 10.5 ms | 13.4 ms | — |
 
 EzXML and LightXML wrap libxml2 (C): faster on raw parse, slower on in-Julia traversal.
 Times include garbage collection; [PERFORMANCE](PERFORMANCE-v0.4.md) breaks each of its rows

--- a/benchmarks/benchmarks_results.md
+++ b/benchmarks/benchmarks_results.md
@@ -2,84 +2,84 @@
 
 ```
 Parse (small)
-	XML.jl             0.0156 ms
-	XML.jl (SS)        0.0141 ms
-	EzXML              0.0133 ms  (XML.jl 17.2% slower)
-	LightXML           0.0112 ms  (XML.jl 38.9% slower)
-	XMLDict             0.116 ms  (XML.jl 86.5% faster)
+	XML.jl             0.0132 ms
+	XML.jl (SS)        0.0123 ms
+	EzXML              0.0126 ms  (~same)
+	LightXML           0.0118 ms  (XML.jl 12.4% slower)
+	XMLDict             0.111 ms  (XML.jl 88.1% faster)
 
 Parse (medium)
-	XML.jl               77.6 ms
-	XML.jl (SS)          74.6 ms
-	EzXML                46.3 ms  (XML.jl 67.7% slower)
-	LightXML             37.5 ms  (XML.jl 106.9% slower)
-	XMLDict             367.0 ms  (XML.jl 78.9% faster)
+	XML.jl               70.0 ms
+	XML.jl (SS)          69.6 ms
+	EzXML                46.3 ms  (XML.jl 51.1% slower)
+	LightXML             36.8 ms  (XML.jl 90.1% slower)
+	XMLDict             353.0 ms  (XML.jl 80.2% faster)
 
 Write (small)
-	XML.jl             0.0056 ms
-	EzXML             0.00556 ms  (~same)
-	LightXML           0.0582 ms  (XML.jl 90.4% faster)
+	XML.jl            0.00559 ms
+	EzXML             0.00578 ms  (~same)
+	LightXML           0.0576 ms  (XML.jl 90.3% faster)
 
 Write (medium)
-	XML.jl               26.8 ms
-	EzXML                21.2 ms  (XML.jl 26.4% slower)
-	LightXML             30.1 ms  (XML.jl 11.0% faster)
+	XML.jl               24.5 ms
+	EzXML                21.3 ms  (XML.jl 14.7% slower)
+	LightXML             30.1 ms  (XML.jl 18.7% faster)
 
 Read file
-	XML.jl               81.9 ms
-	EzXML                58.5 ms  (XML.jl 40.1% slower)
-	LightXML             38.4 ms  (XML.jl 113.1% slower)
+	XML.jl               73.1 ms
+	EzXML                58.6 ms  (XML.jl 24.6% slower)
+	LightXML             39.6 ms  (XML.jl 84.7% slower)
 
 Collect tags (small)
-	XML.jl           0.000369 ms
-	EzXML             0.00112 ms  (XML.jl 67.2% faster)
-	LightXML          0.00187 ms  (XML.jl 80.3% faster)
+	XML.jl            0.00037 ms
+	EzXML             0.00115 ms  (XML.jl 68.0% faster)
+	LightXML          0.00185 ms  (XML.jl 80.0% faster)
 
 Collect tags (medium)
-	XML.jl               4.83 ms
-	EzXML                9.44 ms  (XML.jl 48.8% faster)
-	LightXML             14.2 ms  (XML.jl 65.9% faster)
+	XML.jl               4.79 ms
+	EzXML                10.5 ms  (XML.jl 54.3% faster)
+	LightXML             13.4 ms  (XML.jl 64.2% faster)
 
 Parse SST (LazyNode)
 	XML.jl            4.96e-6 ms
-	Node (for ref)       12.2 ms  (XML.jl 100.0% faster)
+	Node (for ref)       10.0 ms  (XML.jl 100.0% faster)
 
 Parse worksheet (LazyNode)
 	XML.jl            4.96e-6 ms
-	Node (for ref)       21.9 ms  (XML.jl 100.0% faster)
+	Node (for ref)       17.9 ms  (XML.jl 100.0% faster)
 
 SST: write each <si>
-	LazyNode + write (zero-copy)     22.1 ms
-	LazyNode + write (normalize)     55.0 ms
-	Node (for ref)       5.71 ms
+	LazyNode + write (zero-copy)     21.4 ms
+	LazyNode + write (normalize)     52.3 ms
+	Node (for ref)       5.58 ms
 
 SST: unformatted text
-	LazyNode + is_simple_value     25.5 ms
-	Node (for ref)       2.38 ms
+	LazyNode + is_simple_value     23.7 ms
+	Node (for ref)        2.4 ms
 
 Worksheet: collect rows
-	children() (fresh Vector each call)     24.7 ms
-	children!(buf, n) (reused buffer)     24.7 ms
+	children() (fresh Vector each call)     22.8 ms
+	children!(buf, n) (reused buffer)     22.9 ms
 
 Worksheet: attribute scan
-	eachattribute        24.6 ms
-	attributes() (materialize dict)     24.7 ms
+	eachattribute        22.7 ms
+	attributes() (materialize dict)     22.7 ms
 
 Worksheet: single attr fetch
-	get(c, "r", "")      24.7 ms
-	attributes(c)["r"]     24.7 ms
+	get(c, "r", "")      22.7 ms
+	attributes(c)["r"]     22.9 ms
 
 Worksheet: <v> value
-	is_simple_value      24.6 ms
-	is_simple + simple_value     24.7 ms
+	is_simple_value      22.7 ms
+	is_simple + simple_value     22.9 ms
 
 XLSX sst_load! (end-to-end)
-	LazyNode             34.9 ms
-	LazyNode (entity-heavy)     35.4 ms
+	LazyNode             31.7 ms
+	LazyNode (entity-heavy)     32.3 ms
 
 XLSX cell read (end-to-end)
-	numeric ws           25.6 ms
-	string ws            23.3 ms
+	numeric ws           22.7 ms
+	string ws            20.7 ms
 
 ```
 

--- a/src/XMLTokenizer.jl
+++ b/src/XMLTokenizer.jl
@@ -78,11 +78,17 @@ end
 # construction — even in malformed input. This is the package's one deliberate
 # relaxation of the "never index ± 1 on strings" rule; see issue #109.
 #
-# `SubString`'s internal `Val(:noshift)` constructor stores the two fields directly
+# `SubString`'s internal `Val(:noshift)` constructor takes the two fields directly
 # (`base/strings/substring.jl:39-46` as of 1.12.6), unlike the checked constructor
 # whose unconditional `nextind` re-derives the byte length even under `@inbounds`.
 # The `@boundscheck` block preserves full validation under `--check-bounds=yes` (as in
 # `Pkg.test`); callers wrap the call in `@inbounds`, so production builds elide it.
+# Elision reaches one inlining level only, and only into callees that actually inline,
+# so the constructor call below carries its own `@inbounds` plus a callsite `@inline`:
+# Base's constructor validates under its own `@boundscheck` (a `prevind` plus two
+# `isvalid` — `substring.jl:40-44`) and does not inline on its own, which would leave
+# that validation running. The block above already covers it, and `--check-bounds=yes`
+# re-enables every check regardless (#111).
 # If Base ever drops the constructor, the checked index-walking fallback takes over.
 if hasmethod(SubString{String}, Tuple{String, Int, Int, Val{:noshift}})
     @inline function _noshift_substring(s::T, offset::Int, ncu::Int) where {T <: AbstractString}
@@ -96,7 +102,7 @@ if hasmethod(SubString{String}, Tuple{String, Int, Int, Val{:noshift}})
                     throw(StringIndexError(s, offset + ncu + 1))
             end
         end
-        SubString{T}(s, offset, ncu, Val(:noshift))
+        @inbounds @inline SubString{T}(s, offset, ncu, Val(:noshift))
     end
 else
     @inline function _noshift_substring(s::AbstractString, offset::Int, ncu::Int)


### PR DESCRIPTION
Closes #111.

Two annotations complete the elision the span-native design assumed: the view-construction call now carries `@inbounds` plus a callsite `@inline`. Elision reaches one inlining level and applies only to callees that actually inline — Base's noshift constructor did neither (it validates under its own `@boundscheck` and does not inline on its own), so production builds kept paying its `prevind` plus two `isvalid` per view:

```
raw()                                      ← @inbounds here
 └─ _noshift_substring()                   ← level 1: its own @boundscheck (our validation) ELIDED ✓
     └─ SubString{T}(s, off, ncu, noshift) ← level 2: Base's @boundscheck STAYED ACTIVE ✗  — the fix
```

Under `--check-bounds=yes` (as in `Pkg.test`) nothing changes: the flag forces every `@boundscheck` block and ignores `@inbounds`, so the helper's validation — a superset of Base's (it also bounds-checks) — keeps running on every span the suite builds. Behavior is unchanged; the 475-assertion tokenizer testset and the full suite (3987 assertions) are the safety net.

Proof of mechanism: profile self time of `prevind`/`_thisind_str` in the `Node` build drops from ~9.5 % to zero (the residue is Base's own `findnext`/`occursin` boundary checks). Allocations and retained sizes are identical — the removed work was validation index arithmetic, not heap traffic.

BenchmarkTools `@benchmark` medians at default parameters, 14 MB XMark corpus, same-session A/B (A = `3a23839`); tree-walk witnesses identical, external witnesses within their usual band:

| Cell | main | this PR | Δ |
|---|--:|--:|--:|
| lex only (tokenize, no tree) | 25.2 ms | 23.4 ms | **−7 %** |
| parse → DOM (`Node`) | 77.0 ms (GC 17.9) | 62.5 ms (GC 12.9) | **−19 %** |
| build `FlatNode` | 35.1 ms | 28.3 ms | **−19 %** |
| `Cursor` full stream | 29.3 ms | 25.9 ms | **−12 %** |
| `LazyNode` full walk | 186.7 ms | 170.9 ms | **−8 %** |

Docs re-measured in this PR on the unchanged protocol: PERFORMANCE Tables 1–4, the README access-pattern and cross-library tables. Two headline ratios move: `FlatNode` now builds ~1.7× ahead of libxml2 (28.3 vs 47.2 ms), and pure-Julia streaming runs ~2.5× ahead of EzXML's `StreamReader`. Table 2's `String`/`SubString` rows carry larger GC tails than before (25/30 ms vs 20/17) — GC-share redistribution at unchanged allocations, the work share improving ~11 %; the page's protocol note covers exactly this volatility.

The issue called this a one-word fix; it is two — the callsite `@inline` is what makes the `@inbounds` applicable.