### PR TITLE
Add per-reader traversal benchmarks and allocation counts to the pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Measurement upkeep**: every timing in PERFORMANCE-v0.4.md and the README is a
   BenchmarkTools `@benchmark` median (`benchmarks/flatnode_bench.jl` rewritten
   accordingly); the cross-library suite bounds its own C heap (per-sample `finalize`
-  teardown, between-cell collection) so a full run no longer pages the machine; and
-  sub-millisecond README rows are quoted in microseconds (#107, #110).
+  teardown, between-cell collection) so a full run no longer pages the machine;
+  sub-millisecond README rows are quoted in microseconds (#107, #110); and the
+  decomposed pipeline reports the absolute allocation count of every cell and gains a
+  per-reader whole-tree traversal section — a per-node cost hides in a ratio but not in
+  a counter (#120).
 
 ## [0.4.4] - 2026-07-31
 

--- a/PERFORMANCE-v0.4.md
+++ b/PERFORMANCE-v0.4.md
@@ -102,15 +102,17 @@ _Table 3 — the XML.jl pipeline, decomposed (`String` variant)._[^profile]
 
 The lexer is allocation-free; **the whole libxml2 gap is *materialising* the native tree, not scanning it** — and the GC column shows where that cost lives: the allocation-free lex cannot trigger a collection, so every garbage-collector pause inside a parse lands in the build, the toll of 882 K fresh objects.
 
-Traversal of a pre-built tree is allocation-free for **every** reader — the differences are
-pure re-scan work, and the allocation column is measured, not assumed:
+Traversal of a pre-built tree stays off the allocator where it counts — iteration *steps*
+are free for all three readers, and the allocation column is measured, not assumed. `Node`
+and `FlatNode` allocate nothing at all; `LazyNode` allocates one small object per container
+node — its resumable child cursor, elided by the compiler wherever a container is empty:
 
 | Whole-tree traversal (same recursive function) | time | allocations |
 |---|--:|--:|
 | `FlatNode` | 3.8 ms | 0 |
-| `Node` | 4.2 ms | 0 |
-| `LazyNode` | 134 ms | 0 |
-| `LazyNode`, adding the attribute sweep | 142 ms | 0 |
+| `Node` | 4.1 ms | 0 |
+| `LazyNode` | 138 ms | 272,762 |
+| `LazyNode`, adding the attribute sweep | 146 ms | 272,762 |
 
 _Table 3b — whole-tree traversal per reader: one child iterator and a tag + value read per
 visited node (the spreadsheet hot-loop shape). `LazyNode` re-tokenizes everything it steps

--- a/PERFORMANCE-v0.4.md
+++ b/PERFORMANCE-v0.4.md
@@ -60,7 +60,7 @@ Structured pull helpers keep scans cheap without hand-tracked depth: `for_each_c
 
 ### Partial reads — `LazyNode`
 
-Opening is a no-op wrapper (~0.5 µs on this 14 MB file) and nothing is ever cached: each visit re-tokenizes and rebuilds its small handles — allocation-free, the iterators thread their whole state through Julia's iteration protocol — so a repeated look-up costs only its re-scan time, and costs repeat per visit. A traversal pays only for the bytes it actually steps over: the child iterator defers a yielded element's subtree skip until the *next sibling* is requested, so descending to a target is O(bytes before it) — touching this document's root element costs ~4 µs, and a nine-node document-order descent ~5 µs. What still costs: *horizontal* scans pay the subtrees they step past (as any index-free forward reader must), and *repeated* look-ups pay again — those two patterns tip the scale toward `FlatNode`/`Node`.
+Opening is a no-op wrapper (sub-microsecond on this 14 MB file) and nothing is ever cached: each visit re-tokenizes and rebuilds its small handles — allocation-free, the iterators thread their whole state through Julia's iteration protocol — so a repeated look-up costs only its re-scan time, and costs repeat per visit. A traversal pays only for the bytes it actually steps over: the child iterator defers a yielded element's subtree skip until the *next sibling* is requested, so descending to a target is O(bytes before it); scanning *everything* is the worst case, priced per reader in Table 3b. What still costs: *horizontal* scans pay the subtrees they step past (as any index-free forward reader must), and *repeated* look-ups pay again — those two patterns tip the scale toward `FlatNode`/`Node`.
 
 > [!NOTE]
 > Ask only for what you need: a `for` loop over `eachchildnode` fetches the next sibling — and pays its predecessor's deferred subtree skip — at the top of each round, so exit *from within the body* once you are done:
@@ -101,6 +101,20 @@ _Table 2 — full-DOM extraction (parse + pull every tag/text), cross-library._[
 _Table 3 — the XML.jl pipeline, decomposed (`String` variant)._[^profile]
 
 The lexer is allocation-free; **the whole libxml2 gap is *materialising* the native tree, not scanning it** — and the GC column shows where that cost lives: the allocation-free lex cannot trigger a collection, so every garbage-collector pause inside a parse lands in the build, the toll of 882 K fresh objects.
+
+Traversal of a pre-built tree is allocation-free for **every** reader — the differences are
+pure re-scan work, and the allocation column is measured, not assumed:
+
+| Whole-tree traversal (same recursive walk) | time | allocations |
+|---|--:|--:|
+| `FlatNode` | 3.8 ms | 0 |
+| `Node` | 4.2 ms | 0 |
+| `LazyNode` | 134 ms | 0 |
+| `LazyNode`, adding the attribute sweep | 142 ms | 0 |
+
+_Table 3b — whole-tree traversal per reader: one child iterator and a tag + value read per
+visited node (the spreadsheet hot-loop shape). `LazyNode` re-tokenizes everything it steps
+over — pay-per-visit by design; see the partial-reads section for when that trade wins._[^profile]
 
 ### `FlatNode` (v0.4.2, experimental)
 

--- a/PERFORMANCE-v0.4.md
+++ b/PERFORMANCE-v0.4.md
@@ -105,7 +105,7 @@ The lexer is allocation-free; **the whole libxml2 gap is *materialising* the nat
 Traversal of a pre-built tree is allocation-free for **every** reader — the differences are
 pure re-scan work, and the allocation column is measured, not assumed:
 
-| Whole-tree traversal (same recursive walk) | time | allocations |
+| Whole-tree traversal (same recursive function) | time | allocations |
 |---|--:|--:|
 | `FlatNode` | 3.8 ms | 0 |
 | `Node` | 4.2 ms | 0 |

--- a/PERFORMANCE-v0.4.md
+++ b/PERFORMANCE-v0.4.md
@@ -4,7 +4,7 @@ The headline cross-library figures live in the [README](README.md#benchmarks). T
 
 ## The theory behind "optimal"
 
-XML parsing splits into two language-theory levels, and v0.4 hits the **asymptotic lower bound** of each — the sense in which the lexer and parser are "optimal". The gap to a C library like [libxml2](https://en.wikipedia.org/wiki/Libxml2) is constant-factor (C tuning, a leaner non-Julia-heap tree), not asymptotic — and only on the pointer-tree `Node` build; `FlatNode` out-builds libxml2 (Table 4), and at streaming XML.jl is ~2.5× *faster* (Table 1).
+XML parsing splits into two language-theory levels, and v0.4 hits the **asymptotic lower bound** of each — the sense in which the lexer and parser are "optimal". The gap to a C library like [libxml2](https://en.wikipedia.org/wiki/Libxml2) is constant-factor (C tuning, a leaner non-Julia-heap tree), not asymptotic — and only on the pointer-tree `Node` build; `FlatNode` out-builds libxml2 (Table 5), and at streaming XML.jl is ~2.5× *faster* (Table 1).
 
 ### Level 1 — lexing is finite-state
 
@@ -60,7 +60,7 @@ Structured pull helpers keep scans cheap without hand-tracked depth: `for_each_c
 
 ### Partial reads — `LazyNode`
 
-Opening is a no-op wrapper (sub-microsecond on this 14 MB file) and nothing is ever cached: each visit re-tokenizes and rebuilds its small handles — allocation-free, the iterators thread their whole state through Julia's iteration protocol — so a repeated look-up costs only its re-scan time, and costs repeat per visit. A traversal pays only for the bytes it actually steps over: the child iterator defers a yielded element's subtree skip until the *next sibling* is requested, so descending to a target is O(bytes before it); scanning *everything* is the worst case, priced per reader in Table 3b. What still costs: *horizontal* scans pay the subtrees they step past (as any index-free forward reader must), and *repeated* look-ups pay again — those two patterns tip the scale toward `FlatNode`/`Node`.
+Opening is a no-op wrapper (sub-microsecond on this 14 MB file) and nothing is ever cached: each visit re-tokenizes and rebuilds its small handles — allocation-free, the iterators thread their whole state through Julia's iteration protocol — so a repeated look-up costs only its re-scan time, and costs repeat per visit. A traversal pays only for the bytes it actually steps over: the child iterator defers a yielded element's subtree skip until the *next sibling* is requested, so descending to a target is O(bytes before it); scanning *everything* is the worst case, priced per reader in Table 4. What still costs: *horizontal* scans pay the subtrees they step past (as any index-free forward reader must), and *repeated* look-ups pay again — those two patterns tip the scale toward `FlatNode`/`Node`.
 
 > [!NOTE]
 > Ask only for what you need: a `for` loop over `eachchildnode` fetches the next sibling — and pays its predecessor's deferred subtree skip — at the top of each round, so exit *from within the body* once you are done:
@@ -114,7 +114,7 @@ node — its resumable child cursor, elided by the compiler wherever a container
 | `LazyNode` | 138 ms | 272,762 |
 | `LazyNode`, adding the attribute sweep | 146 ms | 272,762 |
 
-_Table 3b — whole-tree traversal per reader: one child iterator and a tag + value read per
+_Table 4 — whole-tree traversal per reader: one child iterator and a tag + value read per
 visited node (the spreadsheet hot-loop shape). `LazyNode` re-tokenizes everything it steps
 over — pay-per-visit by design; see the partial-reads section for when that trade wins._[^profile]
 
@@ -138,7 +138,7 @@ Measured on the same XMark document:
 | `Node` | 70.7 ms (GC 23) | 3.46 ms | 3.7 ms | 71.6 MiB |
 | EzXML (libxml2) | 46.6 ms | — | — | — |
 
-_Table 4 — per-reader full-DOM comparison; *build* is the whole `parse` call, and *DOM size* is the **retained** live tree (`Base.summarysize`), not allocations._[^flatbench]
+_Table 5 — per-reader full-DOM comparison; *build* is the whole `parse` call, and *DOM size* is the **retained** live tree (`Base.summarysize`), not allocations._[^flatbench]
 
 Build allocations: 42.2 MiB (`FlatNode`) vs 99.8 MiB (`Node`), and the *build* ranking puts `FlatNode` ahead of libxml2 itself (~1.7× faster; `Node` sits ~1.5× behind the C library). The GC cells say why `FlatNode` builds so cheaply: its build allocates a handful of arrays instead of 882 K objects, so its median GC share is ~0.1 ms where `Node`'s is ~23 ms. Access on the finished stores: whole-tree walks are close (2.97 vs 3.46 ms — exact-size children vectors keep `Node`'s locality sharp), `parent`/`depth` stay O(1) index hops on `FlatNode` where `Node` must search down from the root, and pure value extraction is close too, flat store slightly ahead (3.1 vs 3.7 ms — a per-value `SubString` view costs two integer stores).
 
@@ -162,4 +162,4 @@ Stream / low-memory / read-only full-DOM / repeated traversal → **XML.jl**; `F
 
 [^profile]: Tables 1–3: measured 2026-08-04 (the `v0.3.9` row: 2026-06-28), Apple M5 (single-threaded), Julia 1.12.6; EzXML 1.2.3 / LightXML 0.9.3 (libxml2 2.15.3); BenchmarkTools at a 5 s budget per cell. Source: [`benchmarks/profile.jl`](benchmarks/profile.jl).
 
-[^flatbench]: Table 4 (and the README access-pattern table): measured 2026-08-04, same machine, Julia and BenchmarkTools settings; source [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl).
+[^flatbench]: Table 5 (and the README access-pattern table): measured 2026-08-04, same machine, Julia and BenchmarkTools settings; source [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl).

--- a/benchmarks/profile.jl
+++ b/benchmarks/profile.jl
@@ -8,9 +8,13 @@
 #   (2) EXTRACT   — parse + pull every tag/text (node counts shown so the work is
 #                   verifiably matched): XML.jl String / SubString  vs  EzXML  vs  LightXML
 #   (3) DECOMPOSE — the XML.jl pipeline stages:  I/O · lex · build · traverse
+#   (4) TRAVERSE  — whole pre-built tree, one `eachchildnode` per visited node, every
+#                   reader through the same protocol: Node / FlatNode / LazyNode
 #
-# Each line shows median time and allocations. A v0.3.9 column for (2)/(3) is added
-# by the subprocess pass in profile_vs_039.jl (run separately).
+# Each line shows the median time, the per-evaluation allocation COUNT, and the
+# allocated bytes — the count is an absolute: a per-node cost hides in a ratio but
+# not in a counter. A v0.3.9 column for (2)/(3) is added by the subprocess pass in
+# profile_vs_039.jl (run separately).
 #
 #   julia --project=benchmarks benchmarks/profile.jl
 
@@ -35,7 +39,8 @@ mib(b) = round(b.memory / 2^20, digits = 1)
 function row(label, b)
     gc = median(b).gctime / 1e6
     tail = gc < 0.05 ? "" : string(" (GC ", round(gc, digits = 1), ")")
-    println(rpad("  " * label, 26), lpad(ms(b), 8), " ms", rpad(tail, 12), lpad(mib(b), 7), " MiB")
+    println(rpad("  " * label, 26), lpad(ms(b), 8), " ms", rpad(tail, 12),
+            lpad(b.allocs, 10), " allocs", lpad(mib(b), 8), " MiB")
 end
 
 #--------------------------------------------------------------# (1) STREAM (no tree)
@@ -105,6 +110,35 @@ function lexcount(s)
     n
 end
 
+#--------------------------------------------------------------# (4) TRAVERSE (per reader)
+# Whole pre-built tree, one child-iterator per visited node — the per-cell hot-loop
+# shape reported from spreadsheet workloads. One walk function, one seam: each reader
+# iterates children through its own protocol (`eachchildnode` for the lazy readers;
+# `Node` stores its children and has no lazy child iterator), so the rows compare the
+# readers' iteration protocols over identical work. The attribute sweep adds
+# `eachattribute`.
+_childiter(n::Node) = something(XML.children(n), ())
+_childiter(n) = XML.eachchildnode(n)
+function traverse_walk(node)
+    cnt = 1; acc = 0
+    t = XML.tag(node);   t === nothing || (acc += sizeof(t))
+    v = XML.value(node); v === nothing || (acc += sizeof(v))
+    for k in _childiter(node)
+        c2, a2 = traverse_walk(k); cnt += c2; acc += a2
+    end
+    (cnt, acc)
+end
+function attr_sweep(node)
+    acc = 0
+    for (k, v) in XML.eachattribute(node)
+        acc += sizeof(k) + sizeof(v)
+    end
+    for ch in XML.eachchildnode(node)
+        acc += attr_sweep(ch)
+    end
+    acc
+end
+
 #--------------------------------------------------------------# Validate (cheap) then benchmark
 println("file: ", round(length(S) / 1e6, digits = 2), " MB")
 cs, es = cursor_stream(S), ezxml_stream(S)
@@ -131,3 +165,16 @@ row("lex only (tokenize)",@benchmark lexcount($S))
 row("parse → DOM",        @benchmark parse($S, Node))
 row("traverse only",      @benchmark xml_walk($TREE))
 println("\n(build ≈ parse − lex; traverse is on a pre-built tree)")
+
+println("\n=== (4) TRAVERSE — whole tree, one eachchildnode per node ===")
+const LAZY = parse(S, LazyNode)
+const FLAT = parse(S, FlatNode)
+let lw = traverse_walk(LAZY), fw = traverse_walk(FLAT), nw = traverse_walk(TREE)
+    println("validation — traverse nodes: Lazy=", lw[1], "  Flat=", fw[1], "  Node=", nw[1])
+end
+row("LazyNode",           @benchmark traverse_walk($LAZY))
+row("FlatNode",           @benchmark traverse_walk($FLAT))
+row("Node",               @benchmark traverse_walk($TREE))
+row("LazyNode attr sweep",@benchmark attr_sweep($LAZY))
+println("\n(same recursive walk for the three readers; a traversal that allocates per",
+        "\n node shows it in the allocs column, not in a ratio)")

--- a/benchmarks/profile.jl
+++ b/benchmarks/profile.jl
@@ -13,8 +13,9 @@
 #
 # Each line shows the median time, the per-evaluation allocation COUNT, and the
 # allocated bytes — the count is an absolute: a per-node cost hides in a ratio but
-# not in a counter. A v0.3.9 column for (2)/(3) is added by the subprocess pass in
-# profile_vs_039.jl (run separately).
+# not in a counter. A previous-release column for (2)/(3) is added by the subprocess
+# pass in profile_vs_039.jl (run separately; it benches the latest local release tag —
+# the published v0.3.9 rows date from when that was the latest).
 #
 #   julia --project=benchmarks benchmarks/profile.jl
 

--- a/benchmarks/profile.jl
+++ b/benchmarks/profile.jl
@@ -13,9 +13,9 @@
 #
 # Each line shows the median time, the per-evaluation allocation COUNT, and the
 # allocated bytes — the count is an absolute: a per-node cost hides in a ratio but
-# not in a counter. A previous-release column for (2)/(3) is added by the subprocess
-# pass in profile_vs_039.jl (run separately; it benches the latest local release tag —
-# the published v0.3.9 rows date from when that was the latest).
+# not in a counter. A v0.3.9 column for (2)/(3) is added by the subprocess
+# pass in profile_vs_039.jl (run separately; the tag is pinned there to the
+# document's comparison point).
 #
 #   julia --project=benchmarks benchmarks/profile.jl
 

--- a/benchmarks/profile.jl
+++ b/benchmarks/profile.jl
@@ -112,7 +112,7 @@ end
 
 #--------------------------------------------------------------# (4) TRAVERSE (per reader)
 # Whole pre-built tree, one child-iterator per visited node — the per-cell hot-loop
-# shape reported from spreadsheet workloads. One walk function, one seam: each reader
+# shape reported from spreadsheet workloads. One traversal function, one seam: each reader
 # iterates children through its own protocol (`eachchildnode` for the lazy readers;
 # `Node` stores its children and has no lazy child iterator), so the rows compare the
 # readers' iteration protocols over identical work. The attribute sweep adds
@@ -176,5 +176,5 @@ row("LazyNode",           @benchmark traverse_walk($LAZY))
 row("FlatNode",           @benchmark traverse_walk($FLAT))
 row("Node",               @benchmark traverse_walk($TREE))
 row("LazyNode attr sweep",@benchmark attr_sweep($LAZY))
-println("\n(same recursive walk for the three readers; a traversal that allocates per",
+println("\n(same recursive traversal for the three readers; a traversal that allocates per",
         "\n node shows it in the allocs column, not in a ratio)")

--- a/benchmarks/profile_vs_039.jl
+++ b/benchmarks/profile_vs_039.jl
@@ -1,9 +1,11 @@
 # benchmarks/profile_vs_039.jl
 #
-# Supplies the v0.3.9 column for profile.jl's DOM regimes. Builds a temp git worktree at
-# the latest release tag and runs the SAME parse + full-walk extraction under 0.3.9 in a
-# clean subprocess (separate temp env), so v0.4 vs 0.3.9 is apples-to-apples for the DOM.
-# 0.3.x has no `Cursor`, so the STREAM regime has no direct 0.3.x analog and is omitted.
+# Supplies the previous-release column for profile.jl's DOM tables. Builds a temp git
+# worktree at the LATEST release tag found locally — the printed label says which tag ran;
+# the published v0.3.9 rows were measured when that was the latest — and runs the SAME
+# parse + full-extraction traversal under it in a clean subprocess (separate temp env),
+# so dev vs release is apples-to-apples for the DOM. 0.3.x has no `Cursor`, so streaming
+# has no direct 0.3.x analog and is omitted.
 #
 #   julia --project=benchmarks benchmarks/profile_vs_039.jl
 
@@ -27,7 +29,7 @@ script  = joinpath(wt, "_b.jl")
 
 run(pipeline(`git -C $ROOT worktree add $wt $TAG`, stdout = devnull, stderr = devnull))
 
-# Subprocess: same walk as profile.jl (touch tag + value on every node), under 0.3.9.
+# Subprocess: same traversal as profile.jl (touch tag + value on every node), under the tag.
 write(script, """
 using Pkg
 Pkg.activate(; temp = true)
@@ -68,7 +70,7 @@ run(pipeline(`git -C $ROOT worktree remove --force $wt`, stdout = devnull, stder
 
 m(b)  = round(median(b).time / 1e6, digits = 2)
 mb(b) = round(b.memory / 2^20, digits = 1)
-println("\n=== v$TAG — the v0.3.9 column (DOM regimes) ===")
+println("\n=== $TAG — the previous-release column (DOM tables) ===")
 println("  nodes walked:     ", res["nodes"],
         "   (v0.4 walks 882026; v0.4 preserves whitespace Text nodes, 0.3.x dropped them)")
 println("  parse → DOM:      ", m(res["parse"]),   " ms / ", mb(res["parse"]),   " MiB")

--- a/benchmarks/profile_vs_039.jl
+++ b/benchmarks/profile_vs_039.jl
@@ -1,11 +1,11 @@
 # benchmarks/profile_vs_039.jl
 #
-# Supplies the previous-release column for profile.jl's DOM tables. Builds a temp git
-# worktree at the LATEST release tag found locally — the printed label says which tag ran;
-# the published v0.3.9 rows were measured when that was the latest — and runs the SAME
-# parse + full-extraction traversal under it in a clean subprocess (separate temp env),
-# so dev vs release is apples-to-apples for the DOM. 0.3.x has no `Cursor`, so streaming
-# has no direct 0.3.x analog and is omitted.
+# Supplies the v0.3.9 column for profile.jl's DOM tables. PERFORMANCE-v0.4.md is a
+# snapshot of v0.4 against v0.3.9 — the 0.3 → 0.4 story — so the tag is PINNED to
+# v0.3.9 below; bump it deliberately if the document's story ever changes. Builds a temp
+# git worktree at that tag and runs the SAME parse + full-extraction traversal under it
+# in a clean subprocess (separate temp env), so dev vs v0.3.9 is apples-to-apples for
+# the DOM. 0.3.x has no `Cursor`, so streaming has no direct 0.3.x analog and is omitted.
 #
 #   julia --project=benchmarks benchmarks/profile_vs_039.jl
 
@@ -15,11 +15,9 @@ const ROOT = dirname(@__DIR__)
 const FILE = joinpath(@__DIR__, "data", "xmark.xml")
 isfile(FILE) || error("generate xmark.xml first (run benchmarks.jl or profile.jl)")
 
-const TAG = let tags = filter(t -> startswith(t, "v"),
-                              readlines(`git -C $ROOT tag --sort=version:refname`))
-    isempty(tags) && error("no vX.Y.Z release tag found locally; `git fetch --tags` first")
-    last(tags)
-end
+const TAG = "v0.3.9"  # the document's comparison point — pinned, not "latest"
+TAG in readlines(`git -C $ROOT tag`) ||
+    error("tag $TAG not found locally; `git fetch --tags` first")
 println("dev profile vs $TAG  (worktree + subprocess) ...")
 
 wt      = mktempdir()
@@ -70,7 +68,7 @@ run(pipeline(`git -C $ROOT worktree remove --force $wt`, stdout = devnull, stder
 
 m(b)  = round(median(b).time / 1e6, digits = 2)
 mb(b) = round(b.memory / 2^20, digits = 1)
-println("\n=== $TAG — the previous-release column (DOM tables) ===")
+println("\n=== $TAG — the v0.3.9 column (DOM tables) ===")
 println("  nodes walked:     ", res["nodes"],
         "   (v0.4 walks 882026; v0.4 preserves whitespace Text nodes, 0.3.x dropped them)")
 println("  parse → DOM:      ", m(res["parse"]),   " ms / ", mb(res["parse"]),   " MiB")


### PR DESCRIPTION
Follow-up to #118/#119: the 2.6 M-allocation lazy-iteration cost lived unseen for months because no benchmark surfaced it as an absolute — the pipeline showed times and bytes, and the per-call microbenches measured the accessors with the iteration in their setup. Two changes close that class of blind spot.

Every `benchmarks/profile.jl` cell now prints its absolute allocation count next to the median time and bytes — a per-node cost hides in a ratio but not in a counter. The count is per evaluation, so a reader can eyeball "allocations ÷ nodes" directly against the validation lines.

A new section (4) traverses the whole pre-built tree through one child iterator per visited node — the spreadsheet hot-loop shape from the #105 field report — for `Node`, `FlatNode`, and `LazyNode` through the same recursive function, plus a `LazyNode` attribute sweep, with a cross-reader node-count validation line. PERFORMANCE-v0.4.md gains the result as Table 4 (the FlatNode comparison becomes Table 5), measured on the #121 resumption semantics:

| Whole-tree traversal (same recursive function) | time | allocations |
|---|--:|--:|
| `FlatNode` | 3.8 ms | 0 |
| `Node` | 4.1 ms | 0 |
| `LazyNode` | 138 ms | 272,762 |
| `LazyNode`, adding the attribute sweep | 146 ms | 272,762 |

Iteration steps are allocation-free for all three readers; `LazyNode`'s count is its one small resumable cursor per container node, elided by the compiler wherever a container is empty. The partial-reads section now points to that table instead of quoting per-path microsecond figures whose measuring method the suite never recorded — every number the section stands on is now reproducible from a script in the repository. The previous-release pass (`profile_vs_039.jl`) is pinned to v0.3.9, the document's comparison point, instead of silently benching the latest local release tag.