### PR TITLE
Restore shared-cursor resumption on the lazy iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`LazyNode` iteration is allocation-free and restartable**: the child, element, and
-  attribute iterators are immutable values that thread the tokenizer's isbits state
-  through Julia's iteration protocol, instead of allocating a mutable tokenizer wrapper,
-  a heap cursor, and a boxed tuple per step. A full lazy traversal of the 14 MB benchmark
-  document drops from 2.6 M allocations / 127 MiB of garbage to zero (median −26 %), and
-  a second pass over the same iterator sees the full sequence again (#118).
+- **`LazyNode` iteration is allocation-light, with its shared-cursor semantics pinned**:
+  the child, element, and attribute iterators hold the tokenizer's isbits state as inline
+  fields — no per-call mutable tokenizer wrapper, no heap `RefValue` cursor, no boxed
+  tuple per step. Pulling children through an iterator allocates nothing; creating one
+  costs a single small object, elided where it never loops. Every loop over the same
+  iterator object resumes where the previous one stopped — the contract downstream row
+  streams (XLSX.jl) rely on, now pinned in tests. A full lazy traversal of the 14 MB
+  benchmark document drops from 2.6 M allocations / 127 MiB of garbage to 273 K / 21 MiB,
+  median −23 % (#118, #119, #121).
 
 - **The `Node` build no longer allocates per-element vectors**: children and attributes
   accumulate on parse-wide scratch stacks, sliced out exact-size at each closing tag. On

--- a/src/lazynode.jl
+++ b/src/lazynode.jl
@@ -134,14 +134,13 @@ without allocating, or [`attributes`](@ref) for the materialized dict.
 end
 
 #-----------------------------------------------------------------------------# eachattribute
-# Immutable on purpose: the wrapped tokenizer carries all iteration state, so the wrapper
-# itself never mutates — which lets the whole iterator (tokenizer included) stay
-# stack-allocated when a `for` loop inlines it (#105). The standard iteration contract
-# applies: `iterate` must not be called again after it has returned `nothing`.
-struct LazyAttrIterator{S <: AbstractString}
-    data::S
-    t::Tokenizer{S}
-    start::TokenizerState
+# Same shared-cursor design as `LazyChildIterator`: the isbits tokenizer state lives in
+# a mutable field, so every loop over the same object resumes where the last one stopped,
+# and an exhausted iterator stays exhausted (`active` latches false).
+mutable struct LazyAttrIterator{S <: AbstractString}
+    const data::S
+    const t::Tokenizer{S}
+    state::TokenizerState
     active::Bool
 end
 
@@ -170,17 +169,18 @@ as the match is found.
     LazyAttrIterator{S}(n.data, t, st, is_attrs)
 end
 
-@inline function Base.iterate(it::LazyAttrIterator, st::TokenizerState = it.start)
+@inline function Base.iterate(it::LazyAttrIterator, _ = nothing)
     it.active || return nothing
-    r = iterate(it.t, st)
-    isnothing(r) && return nothing
+    r = iterate(it.t, it.state)
+    isnothing(r) && (it.active = false; return nothing)
     tok, st = r
-    tok.kind === TokenKinds.ATTR_NAME || return nothing
+    tok.kind === TokenKinds.ATTR_NAME || (it.active = false; return nothing)
     name = raw(tok, it.data)
     r = iterate(it.t, st)
-    isnothing(r) && return nothing
+    isnothing(r) && (it.active = false; return nothing)
     vtok, st = r
-    ((name => _decode_attr(vtok, it.data)), st)
+    it.state = st
+    ((name => _decode_attr(vtok, it.data)), nothing)
 end
 
 #-----------------------------------------------------------------------------# foreach_attr
@@ -494,14 +494,16 @@ const _CI_READY   = 0x00
 const _CI_PENDING = 0x01  # an element was yielded; its unskipped subtree lies ahead
 const _CI_DONE    = 0x02
 
-# Fully functional: the tokenizer's isbits state and the phase flag travel in `iterate`'s
-# state tuple, so the iterator is immutable, restartable, and the whole protocol keeps to
-# the stack — no per-call tokenizer wrapper, no heap cursor (#118).
-struct LazyChildIterator{S <: AbstractString}
-    data::S
-    t::Tokenizer{S}
-    start::TokenizerState
-    phase0::UInt8  # _CI_READY, or _CI_DONE for childless node kinds
+# One shared cursor per iterator object, held as inline isbits fields (no `Ref`, no
+# mutable tokenizer wrapper): every loop over the same object RESUMES where the last one
+# stopped — downstream row streams (XLSX.jl) store one child iterator and pull from it
+# with a fresh `for … break` per row, so the resumption semantics are load-bearing. When
+# the iterator does not escape its loop, escape analysis keeps the object off the heap.
+mutable struct LazyChildIterator{S <: AbstractString}
+    const data::S
+    const t::Tokenizer{S}
+    state::TokenizerState
+    phase::UInt8  # _CI_READY / _CI_PENDING / _CI_DONE
 end
 
 Base.IteratorSize(::Type{<:LazyChildIterator}) = Base.SizeUnknown()
@@ -515,7 +517,7 @@ without collecting them all into a vector.
 
 See also [`children`](@ref), which returns a `Vector{LazyNode}`.
 """
-function eachchildnode(n::LazyNode{S}) where {S}
+@inline function eachchildnode(n::LazyNode{S}) where {S}
     nt = n.nodetype
     t = Tokenizer(n.data, _lazy_pos(n))
     st = _init_state(t)
@@ -546,33 +548,38 @@ end
 Base.IteratorSize(::Type{<:LazyElementIterator}) = Base.SizeUnknown()
 Base.eltype(::Type{LazyElementIterator{S}}) where {S} = LazyNode{S}
 
-eachelement(node::LazyNode) = LazyElementIterator(eachchildnode(node))
+@inline eachelement(node::LazyNode) = LazyElementIterator(eachchildnode(node))
 
-@inline Base.iterate(ei::LazyElementIterator) = _ei_filter(ei.ci, iterate(ei.ci))
-@inline Base.iterate(ei::LazyElementIterator, s::Tuple{TokenizerState, UInt8}) = _ei_filter(ei.ci, iterate(ei.ci, s))
-@inline function _ei_filter(ci::LazyChildIterator, r)
-    while r !== nothing
+@inline Base.iterate(ei::LazyElementIterator, _ = nothing) = _ei_filter(ei.ci)
+@inline function _ei_filter(ci::LazyChildIterator)
+    while true
+        r = iterate(ci)
+        r === nothing && return nothing
         r[1].nodetype === Element && return r
-        r = iterate(ci, r[2])
     end
-    nothing
 end
 
-@inline Base.iterate(ci::LazyChildIterator) = _ci_next(ci, ci.start, ci.phase0)
-@inline Base.iterate(ci::LazyChildIterator, s::Tuple{TokenizerState, UInt8}) = _ci_next(ci, s[1], s[2])
+# The passed iteration state is ignored — the cursor lives in the iterator's own fields
+# (the resumption contract above). The yielded tuple is built at a SINGLE site — an
+# unboxed union return survives only one construction path (the same rule the span→view
+# helpers pin down) — and the chain must inline into the caller's loop: across a
+# non-inlined boundary the union boxes per step.
+@inline Base.iterate(ci::LazyChildIterator, _ = nothing) = _ci_next(ci)
 
-# The yielded tuple is built at a SINGLE site — an unboxed union return survives only one
-# construction path (the same rule the span→view helpers pin down) — and the chain must
-# inline into the caller's loop: across a non-inlined boundary the union boxes per step.
-@inline function _ci_next(ci::LazyChildIterator, st::TokenizerState, phase::UInt8)
+@inline function _ci_next(ci::LazyChildIterator)
+    phase = ci.phase
     phase === _CI_DONE && return nothing
     t = ci.t
+    st = ci.state
     if phase === _CI_PENDING
         st = _skip_element(t, st)
     end
     while true
         r = iterate(t, st)
-        isnothing(r) && return nothing
+        if isnothing(r)
+            ci.phase = _CI_DONE
+            return nothing
+        end
         tok, st = r
         k = tok.kind
         newphase = _CI_READY
@@ -598,11 +605,14 @@ end
             nt = DTD
             st = _skip_until(t, st, TokenKinds.DOCTYPE_CLOSE)
         elseif k === TokenKinds.CLOSE_TAG || k === TokenKinds.TAG_CLOSE
+            ci.phase = _CI_DONE
             return nothing
         else
             continue
         end
-        return (LazyNode(ci.data, tok, nt), (st, newphase))
+        ci.state = st
+        ci.phase = newphase
+        return (LazyNode(ci.data, tok, nt), nothing)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3887,19 +3887,31 @@ end
             @test isempty(collect(eachchildnode(comment)))
         end
 
-        @testset "iterators are restartable" begin
-            # The child and element iterators are immutable values threading their whole
-            # state through `iterate` — a second full pass over the SAME iterator object
-            # sees the same sequence (a shared-cursor design would come back empty).
-            xml = "<root><a/>text<b><c/></b><!-- x --></root>"
+        @testset "iterators resume across loops (shared-cursor contract)" begin
+            # Downstream consumers (XLSX.jl's row stream) store one child iterator and
+            # pull from it with a fresh `for … break` per row, relying on the cursor
+            # advancing past everything already yielded. Pin that contract: a second
+            # loop over the SAME iterator object resumes after the last yielded node —
+            # it does not restart — and an exhausted iterator stays exhausted.
+            xml = "<root><a/>text<b><c/></b><!-- x --><d/></root>"
             root = parse(xml, LazyNode)[1]
             it = eachchildnode(root)
-            first_pass = map(nodetype, collect(it))
-            @test map(nodetype, collect(it)) == first_pass
-            @test length(first_pass) == 4
+            first_nt = nothing
+            for ch in it
+                first_nt = nodetype(ch)
+                break
+            end
+            @test first_nt == Element                              # <a/>
+            @test [nodetype(ch) for ch in it] == [Text, Element, Comment, Element]
+            @test isempty(collect(it))
+
             ei = eachelement(root)
-            @test map(tag, collect(ei)) == ["a", "b"]
-            @test map(tag, collect(ei)) == ["a", "b"]
+            @test tag(first(ei)) == "a"
+            @test [tag(e) for e in ei] == ["b", "d"]
+
+            at = eachattribute(parse("""<e x="1" y="2" z="3"/>""", LazyNode)[1])
+            @test first(at)[1] == "x"
+            @test [String(k) for (k, _) in at] == ["y", "z"]
         end
 
         @testset "deep recursive equivalence with Node" begin

--- a/test/test_allocations.jl
+++ b/test/test_allocations.jl
@@ -131,9 +131,12 @@ end
     end
 end
 
-# Lazy child iteration — the protocol itself must not allocate: no per-call tokenizer
-# wrapper, no heap cursor, no boxed iteration tuple. The recursive traversal is the
-# field-report shape (one eachchildnode per visited node, spreadsheet-style hot loop).
+# Lazy child iteration — the iteration protocol must not allocate: pulling any number of
+# children through an already-created iterator is 0 B (no per-step tuple boxing, no heap
+# cursor cell, no per-call tokenizer wrapper). Creating an iterator costs one small
+# mutable object — its shared, resumable cursor, the semantics downstream row streams
+# (XLSX.jl) depend on — and escape analysis elides it when the iterator dies without
+# looping, so a recursive traversal allocates at most one object per container node.
 function walk_count(n)
     c = 1
     for ch in XML.eachchildnode(n)
@@ -152,21 +155,43 @@ function element_count(n)
 end
 measure_elements(n) = @allocated element_count(n)
 
-@testset "Lazy iteration: allocation-free traversal" begin
+function consume_count(it)
+    c = 0
+    for _ in it
+        c += 1
+    end
+    c
+end
+measure_consume(it) = @allocated consume_count(it)
+measure_mk_child(n) = @allocated XML.eachchildnode(n)
+
+@testset "Lazy iteration: allocation-light traversal" begin
     torture_xml = """<?xml version="1.0"?><!-- top --><r a="1">t1<e1 x="y"><in>deep</in><self/></e1><!-- c --><![CDATA[cd]]><?pi d?><e2>café</e2>tail</r>"""
     doc = parse(torture_xml, LazyNode)
+    attr_el = only(eachelement(parse("""<e x="1" y="2" z="3"/>""", LazyNode)))
 
     @testset "traversal reads correctly" begin
         @test walk_count(doc) == 15       # doubles as compile warm-up
         @test element_count(doc) == 5
+        @test consume_count(XML.eachchildnode(doc)) == 3
+        @test consume_count(eachattribute(attr_el)) == 3
+        measure_mk_child(doc)             # warm-up for the creation guard
     end
 
     if _NO_COVERAGE
-        @testset "recursive eachchildnode traversal" begin
-            @test measure_walk(doc) == 0
+        @testset "consuming a pre-built iterator is free" begin
+            @test measure_consume(XML.eachchildnode(doc)) == 0
+            @test measure_consume(eachelement(doc)) == 0
+            @test measure_consume(eachattribute(attr_el)) == 0
         end
-        @testset "eachelement traversal" begin
-            @test measure_elements(doc) == 0
+        @testset "iterator creation is one small object" begin
+            @test measure_mk_child(doc) <= 96
+        end
+        @testset "recursive traversal: at most one object per container node" begin
+            # 6 containers here (the document + 5 elements); ceilings hold even if a
+            # future compiler elides more of them.
+            @test measure_walk(doc) <= 6 * 96
+            @test measure_elements(doc) <= 6 * 96
         end
     end
 end


### PR DESCRIPTION
#119 hangs XLSX.jl. Its row stream stores one `eachchildnode` iterator and pulls from it with a fresh `for … break` per row ([stream.jl:100-129](https://github.com/JuliaData/XLSX.jl/blob/master/src/stream.jl#L100-L129)), relying on the cursor advancing past everything already yielded — and #119's iterators, being immutable values, restart every loop from the beginning: the stream finds row 1 forever. That is the Downstream job hanging for 10+ hours on the last three runs, and it reproduces locally in seconds (a two-row workbook reads 10,000+ rows before a cut-off; with this fix it reads 2 and finishes).

The fix keeps #119's structure and gives the cursor back: the child, element, and attribute iterators become `mutable struct`s holding the tokenizer's isbits state as inline fields (`const` data and tokenizer beside them) — the pre-#119 resumption semantics with none of its three heap objects per node. No `StatefulTokenizer` per call, no `RefValue` cell, no boxed tuple per step; iteration steps allocate nothing, and the one small object per iterator is elided by escape analysis when it never loops (empty and self-closing containers).

| full lazy traversal, 14 MB document | time | allocations | XLSX row stream |
|---|--:|--:|---|
| pre-#119 (shared mutable cursor) | 174 ms | 2,646,077 / 127 MiB | works |
| #119 (immutable, functional state) | 129.5 ms | 0 | **hangs** |
| this PR (mutable, inline isbits state) | 133.5 ms | 272,762 / 21 MiB | works |

The resumption contract is now pinned in tests — a second loop over the same iterator resumes after the last yielded node, an exhausted iterator stays exhausted — exactly the shape XLSX pulls with, so this cannot regress silently again. The allocation guards move to the contracts this design makes: consuming a pre-built iterator is 0 B; creating one costs a single small object. `Pkg.test`: 4017/4017 under the default `--check-bounds=yes`; under `auto`, the only failure is the pre-existing `FlatNode` guard, identical on `main`.

Note for #120: its Table 3b quotes the `LazyNode` traversal rows measured on #119's code (134 ms, 0 allocations); once this merges, those rows should be re-measured before #120 lands.