### PR TITLE
Unbox `simple_value(::FlatNode)` on the default-bounds build, and make CI test that build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,3 +51,36 @@ jobs:
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
+  test-default-bounds:
+    # The build users actually run: --check-bounds=auto makes the load-time selection
+    # compile the noshift span reconstruction (Pkg.test's default --check-bounds=yes
+    # compiles the checked branch instead, leaving the user-facing path untested), and
+    # coverage off lets the numeric allocation guards assert (coverage counters allocate
+    # inside the measured calls, so the guards skip themselves under coverage).
+    name: Julia 1 - ubuntu-latest - x64 - default-bounds allocation guards
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: '1'
+          arch: x64
+      - uses: actions/cache@v6
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: actions/cache@v6
+        with:
+          path: test/data/w3c
+          key: w3c-xmlconf-v20130923
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          coverage: false
+          julia_args: '--check-bounds=auto'

--- a/src/flatnode.jl
+++ b/src/flatnode.jl
@@ -482,9 +482,16 @@ is_simple(n::FlatNode) = (r = _rec(n);
     r.kind === Element && r.attr_count == 0 && r.first_child != 0 &&
     (c = @inbounds n.store.recs[r.first_child]; c.next_sibling == 0 && (c.kind === Text || c.kind === CData)))
 
-# Hand-flattened `value(FlatNode(n.store, _rec(n).first_child))`: the extra call depth
-# pushed the SubString constructor past the inlining budget, and a constructor left as
-# `invoke` heap-materializes the returned view — 32 B per call (#105).
+# Both bodies below are `value(::FlatNode)` hand-applied to the child record, and the
+# duplication is DELIBERATE — do not factor it into a shared helper. Through any extra
+# call depth (the old `value(FlatNode(store, first_child))` route, or a shared helper —
+# measured with a definition-site `@inline` and with a callsite `@inline`), the
+# `@inbounds` chain stops reaching the noshift constructor's own `@boundscheck` (elision
+# crosses one level, into inlined callees only): the constructor then inlines *with* its
+# checked machinery, and those branches around the view construction re-box the union
+# return — 32 B per call on the default-bounds build, invisible to `Pkg.test`, whose
+# `--check-bounds=yes` selects the checked reconstruction body outright. The allocation
+# guards enforce both copies (#111, #113, #114).
 @inline function is_simple_value(n::FlatNode)
     is_simple(n) || return nothing
     c = @inbounds n.store.recs[_rec(n).first_child]
@@ -493,9 +500,12 @@ is_simple(n::FlatNode) = (r = _rec(n);
     c.value_len < 0 ? unescape(raw) : raw
 end
 
-function simple_value(n::FlatNode)
+@inline function simple_value(n::FlatNode)
     is_simple(n) || error("`simple_value` requires a simple node: an Element with no attributes and exactly one Text or CData child. See `is_simple`.")
-    value(FlatNode(n.store, _rec(n).first_child))
+    c = @inbounds n.store.recs[_rec(n).first_child]
+    c.value_offset < 0 && return nothing
+    raw = _fsub(n.store, c.value_offset, abs(c.value_len))
+    c.value_len < 0 ? unescape(raw) : raw
 end
 
 #-----------------------------------------------------------------------------# conversion / write / show

--- a/test/test_allocations.jl
+++ b/test/test_allocations.jl
@@ -195,3 +195,19 @@ measure_mk_child(n) = @allocated XML.eachchildnode(n)
         end
     end
 end
+
+# Node build — the scratch-stack contract: children and attributes accumulate on
+# parse-wide stacks, sliced out exact-size at each closing tag (no per-element vector
+# churn). 400 one-attribute one-text elements cost ~4.0 K allocations today; a churn
+# regression re-adds at least two vectors per element (≥ +800), so the ceiling sits
+# between the two and survives version-to-version noise.
+measure_node_build_allocs(xml) = Base.@allocations parse(xml, Node)
+
+@testset "Node build: scratch-stack allocation ceiling" begin
+    churn_xml = "<root>" * repeat("<e a=\"1\">t</e>", 400) * "</root>"
+    @test length(children(only(children(parse(churn_xml, Node))))) == 400
+    measure_node_build_allocs(churn_xml)   # warm-up
+    if _NO_COVERAGE
+        @test measure_node_build_allocs(churn_xml) <= 4500
+    end
+end


### PR DESCRIPTION
A pre-v0.4.5 audit found that `simple_value(::FlatNode)` heap-allocates 32 B per call on the build users actually run — a regression from #114, measured at 0 B on its parent commit and 32 B at its merge — invisible to every existing check: `Pkg.test` forces `--check-bounds=yes`, which compiles the other reconstruction branch, and CI's coverage runs make the allocation guards skip themselves.

#114 rerouted `_fsub` from the checked `SubString` constructor to the load-time-selected noshift one; the mechanism, read from the typed IR on both sides: through the extra call depth of `simple_value`'s `value(FlatNode(store, first_child))` delegation, the `@inbounds` chain stops reaching the noshift constructor's own `@boundscheck` — elision crosses one level, into inlined callees only — so the constructor inlines *with* its checked machinery, and those branches around the view construction re-box the union return.

The fix is the same hand-flattening as the adjacent `is_simple_value`; the *existing* guard turns green under `--check-bounds=auto`.

Note that the two flattened bodies stay deliberately duplicated — factoring them into a shared helper re-boxes the union return however the helper is inlined (measured both ways); a source comment pins that, and the guards enforce both copies.

The structural hole gets closed too: a new CI job runs the suite with `--check-bounds=auto` and coverage off — the first configuration that compiles the user-facing noshift span path at all, and the first where the allocation guards actually assert. That one job would have caught this before release.

The `Node` build also gains its missing allocation guard: a 400-element ceiling pinning the parse-wide scratch-stack contract from #107 (a churn regression re-adds at least two vectors per element, +800 allocations, and blows the 4,500 ceiling; today's build sits at ~4,000).

`Pkg.test`: 4019/4019 under `--check-bounds=yes` **and** under `auto` — the first fully green default-bounds run.