### PR TITLE
Fix the Julia 1.10 breakage (XLSX.jl#448): restore the two-branch span fallback

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,13 +57,21 @@ jobs:
     # compiles the checked branch instead, leaving the user-facing path untested), and
     # coverage off lets the numeric allocation guards assert (coverage counters allocate
     # inside the measured calls, so the guards skip themselves under coverage).
-    name: Julia 1 - ubuntu-latest - x64 - default-bounds allocation guards
+    # 'lts' is a third body again: Base has no noshift SubString constructor on 1.10,
+    # so that build selects the two-branch fallback under either flag.
+    name: Julia ${{ matrix.version }} - ubuntu-latest - x64 - default-bounds allocation guards
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1'
+          - 'lts'
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: '1'
+          version: ${{ matrix.version }}
           arch: x64
       - uses: actions/cache@v6
         env:

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.package }}
+    name: ${{ matrix.package }} - Julia ${{ matrix.version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -15,11 +15,17 @@ jobs:
         package:
           - "SatelliteToolboxOrbitDataMessages"
           - "XLSX"
+        # 'lts' runs the fallback span reconstruction (Base has no noshift SubString
+        # constructor on 1.10), a different compiled body than '1' — and dependents are
+        # the only callers large enough to exercise it the way users do.
+        version:
+          - '1'
+          - 'lts'
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: 1
+          version: ${{ matrix.version }}
           arch: x64
           show-versioninfo: true
       - uses: julia-actions/julia-buildpkg@latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to XML.jl will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Julia 1.10 builds mis-executed downstream worksheet scans** — XLSX.jl workbook opens failed with `No sheetData node found in worksheet` ([XLSX.jl#448](https://github.com/JuliaData/XLSX.jl/issues/448)): a Julia 1.10 compilation defect triggered by v0.4.5's branchless span fallback. The 1.10 build now selects the earlier two-branch body (1.11+ builds are unchanged), and the Downstream and default-bounds CI jobs also run on LTS.
+
 ## [0.4.5] - 2026-08-13
 
 ### Added

--- a/src/XMLTokenizer.jl
+++ b/src/XMLTokenizer.jl
@@ -92,9 +92,21 @@ if hasmethod(SubString{String}, Tuple{String, Int, Int, Val{:noshift}}) &&
    Base.JLOptions().check_bounds != 1
     @inline _noshift_substring(s::T, offset::Int, ncu::Int) where {T <: AbstractString} =
         @inbounds @inline SubString{T}(s, offset, ncu, Val(:noshift))
-else
+elseif hasmethod(SubString{String}, Tuple{String, Int, Int, Val{:noshift}})
+    # 1.11+ under `--check-bounds=yes` (`hasmethod` is a generation test — this body
+    # never calls the noshift constructor): keep the branchless checked shape, whose
+    # single construction path leaves union returns unboxed under `yes` (#113).
     _noshift_substring(s::AbstractString, offset::Int, ncu::Int) =
         @inline _checked_substring(s, offset, ncu)
+else
+    # Julia 1.10, either bounds flag (Base has no noshift constructor there). The
+    # branchless shape above makes 1.10 mis-compile large callers — stale reads of an
+    # escaping `Cursor` (JuliaData/XLSX.jl#448); this pre-#114 two-branch shape,
+    # green on 1.10 through v0.4.2–v0.4.4, avoids it. Details: the fix PR.
+    @inline function _noshift_substring(s::AbstractString, offset::Int, ncu::Int)
+        ncu == 0 && return SubString(s, 1, 0)
+        SubString(s, offset + 1, prevind(s, offset + ncu + 1))
+    end
 end
 
 # Recover the token's text as a zero-copy `SubString` of its source `data` — a direct

--- a/test/test_allocations.jl
+++ b/test/test_allocations.jl
@@ -13,6 +13,12 @@ using XML: unescape
 # inside the measured call (same gate as the `_normalize_attr_ws` guard in runtests.jl).
 const _NO_COVERAGE = Base.JLOptions().code_coverage == 0
 
+# `Node`'s by-key attribute lookups return through a union boundary that the 1.10 and
+# 1.11 inliners do not flatten, so each call re-boxes (32 B) there under either bounds
+# flag — measured identically on v0.4.4 and v0.4.5, a compiler-generation limit rather
+# than a package regression; 1.12 returns it unboxed and holds the zero guard.
+const _ND_BYKEY_CEILING = VERSION < v"1.12" ? 32 : 0
+
 _use(v) = v === nothing ? 0 : ncodeunits(v)
 
 measure_get(x)       = @allocated _use(get(x, "r", nothing))
@@ -90,15 +96,15 @@ end
             @test measure_get(lz) == 0
             @test measure_get(fl) == 0
             @test measure_get(cu) == 0
-            @test measure_get(nd) == 0
+            @test measure_get(nd) <= _ND_BYKEY_CEILING
             @test measure_index(lz) == 0
             @test measure_index(fl) == 0
             @test measure_index(cu) == 0
-            @test measure_index(nd) == 0
+            @test measure_index(nd) <= _ND_BYKEY_CEILING
             @test measure_haskey(lz) == 0
             @test measure_haskey(fl) == 0
             @test measure_haskey(cu) == 0
-            @test measure_haskey(nd) == 0
+            @test measure_haskey(nd) <= _ND_BYKEY_CEILING
         end
 
         @testset "tag" begin


### PR DESCRIPTION
Fixes the Julia 1.10 breakage reported in JuliaData/XLSX.jl#448 and raised on #121: with XML 0.4.5, every XLSX.jl workbook open on Julia 1.10 fails with `No sheetData node found in worksheet`.

**Cause.** A Julia 1.10 optimizer defect, triggered by #114: the compiled scan keeps the `Cursor`'s field updates in registers — never written back to the heap object — while the non-inlined `tag(::Cursor)` reads that object, so it sees the construction-time state forever and nothing matches. The branchless #114 fallback (the body every 1.10 build compiles, `Base` lacking the noshift constructor there) is what stops 1.10's inliner from inlining `tag` in large callers; the earlier two-branch body inlines it — hence the fix. Affects 1.10.5–1.10.12 under either bounds flag; 1.11/1.12 are correct. 
No JuliaLang/julia report yet — a self-contained reproducer was worked out with Claude; I need to review it fully before filing an issue.

**Fix.** Three-way load-time selection — every configuration keeps a shape already green in that exact configuration:
- 1.11+ default builds — noshift store, unchanged;
- 1.11+ `--check-bounds=yes` (as in `Pkg.test`) — branchless checked reconstruction, unchanged;
- 1.10, either flag — the pre-#114 two-branch body, green there through v0.4.2–v0.4.4.

**Verification.** XLSX.jl's `openxlsx` witness: green with this branch on 1.10.5–1.10.12, 1.11, and 1.12; red on v0.4.5 on every 1.10 patch tried. Full suite green on 1.12 (bodies byte-identical) and on 1.10 (guard ceiling below), both flags. Benchmarks (BenchmarkTools medians, interleaved A/B): 1.12 is a strict no-op; on 1.10.12 vs v0.4.5 the cursor scan drops from 64 003 allocations to 1 (~6 % faster) while the `Node` and lazy builds pay +3.6 %/+5.8 % — and every axis stays 23–31 % ahead of v0.4.4, the last correct release on LTS.

**Coverage.** No job saw the failing configuration — Downstream ran on `'1'` only, and the LTS leg tests under `--check-bounds=yes` with coverage on, which skips the numeric guards — as the analysis quoted on #121 pointed out. Downstream and the default-bounds job now run on `'lts'` too. No in-suite regression test: the mis-compilation is perturbation-sensitive, so real dependents on LTS are the honest net.

**Guards.** The three `Node` by-key guards measure 32 B on 1.10 and 1.11 under either flag, on v0.4.4 and v0.4.5 alike — a compiler-generation limit, not a regression; ceilinged below 1.12 so the new LTS guard leg is meaningful.