### PR TITLE
Declare escape and unescape as public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to XML.jl will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`XML.escape` and `XML.unescape` are now public API** ([#125](https://github.com/JuliaData/XML.jl/issues/125)): declared `public` on Julia 1.11+ (a no-op on 1.10, which has no such notion) and covered by semver, for downstream code that assembles XML strings itself, as XLSX.jl does. They stay unexported — the bare names are too generic to bring into scope with `using XML`. `escape` handles all five predefined entities, so it is safe for quoted attribute values as well as text content.
+
 ## [0.4.6] - 2026-08-17
 
 ### Fixed
@@ -409,6 +415,7 @@ First release since XML.jl moved to [JuliaData](https://github.com/JuliaData/XML
 
 - Initial release.
 
+[Unreleased]: https://github.com/JuliaData/XML.jl/compare/v0.4.6...HEAD
 [0.4.6]: https://github.com/JuliaData/XML.jl/compare/v0.4.5...v0.4.6
 [0.4.5]: https://github.com/JuliaData/XML.jl/compare/v0.4.4...v0.4.5
 [0.4.4]: https://github.com/JuliaData/XML.jl/compare/v0.4.3...v0.4.4

--- a/src/XML.jl
+++ b/src/XML.jl
@@ -11,7 +11,12 @@ export
     Cursor, next!, for_each_child, @for_each_child, skip_element!, eof,
     xpath,
     h
-    
+
+# `escape`/`unescape` are supported API but stay unexported (the bare names are too
+# generic to bring into scope with `using XML`). The `public` keyword only parses on
+# Julia 1.11+, hence the guarded `eval` — a no-op on 1.10, which has no such notion.
+VERSION >= v"1.11" && eval(Meta.parse("public escape, unescape"))
+
 include("XMLTokenizer.jl")
 using .XMLTokenizer:
     XMLTokenizer, tokenize, tag_name, attr_value, pi_target, raw,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,15 @@ Test.push_testset(_ROOT_TS)
 #                              ESCAPE / UNESCAPE                               #
 #==============================================================================#
 @testset "escape / unescape" begin
+    @testset "declared public, not exported" begin
+        if VERSION >= v"1.11"   # `Base.ispublic` and the `public` notion exist from 1.11
+            @test Base.ispublic(XML, :escape)
+            @test Base.ispublic(XML, :unescape)
+        end
+        @test !Base.isexported(XML, :escape)
+        @test !Base.isexported(XML, :unescape)
+    end
+
     @testset "all five predefined entities" begin
         @test escape("&") == "&amp;"
         @test escape("<") == "&lt;"


### PR DESCRIPTION
Closes #125.

`XML.escape` and `XML.unescape` have reference docstrings and downstream users — XLSX.jl escapes the XML strings it assembles itself, for consistency with the writer — but were never declared public. This PR declares them `public` on Julia 1.11+ through a guarded `eval`, since the keyword is a parse error on 1.10; there the declaration is a no-op, as the notion does not exist. They stay unexported: the bare names are too generic to bring into scope with `using XML`.

Contract now covered by semver: `escape` escapes all five predefined entities, so it is safe for quoted attribute values as well as text content, and — since v0.4 — it is not idempotent (every `&` is escaped: call it on raw text only); `unescape` decodes the five predefined entities and decimal/hex character references. The docstrings already state all of this.

Tests assert the declaration on 1.11+ and that the names remain unexported; CHANGELOG entry added.