### PR TITLE
`:strict` reference check: one pass over the bytes, no allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`unescape` allocated about six times per value carrying a reference** ([#141](https://github.com/JuliaData/XML.jl/issues/141)): it copied its argument to a `String`, ran a regular-expression `replace` and built a string per character reference, in every reader. It now decodes in one pass over the bytes and allocates once, the result; a value whose `&` starts no reference is returned as it is. On the escaped twin of the benchmarks, a `Cursor` pass drops from 269,015 to 46,584 allocations and from 38.2 to 30.7 ms; on a value of a spreadsheet cell's shape, from 171 to 34 ns per call.
 
+- **The `:strict` reference check allocated about seven times per reference** ([#142](https://github.com/JuliaData/XML.jl/issues/142)): it matched a regular expression per reference in every token carrying a `&`, in the `Node` and `FlatNode` parses alike. It now reads the token's bytes and allocates nothing, so `:strict` allocates exactly what `:structural` does; what it accepts and rejects is unchanged. On the escaped twin of the benchmarks, `parse(…, Node; wellformed = :strict)` goes from 3,241,570 to 2,658,494 allocations and from 89.8 to 68.9 ms. The decoder behind `unescape` and the check now share one reader of references.
+
 ## [0.4.6] - 2026-08-17
 
 ### Fixed

--- a/PERFORMANCE-v0.4.md
+++ b/PERFORMANCE-v0.4.md
@@ -183,19 +183,19 @@ The two libxml2 rows put the C library on the same three documents. Its reader t
 
 ### Well-formedness levels
 
-`:strict` adds two checks over `:structural`: a character-range scan of every text, attribute value, comment, CDATA section and processing-instruction body, and a check of every reference in a token that carries one, against the character range for a numeric reference and against the five predefined names for a named one, every declared entity having been included by then. The first costs in proportion to the document's text share, the second to its reference density, and the XMark-style document, which has no reference at all, measures the first alone. `:lenient` and `:structural` differ only in the document-shape checks, whose cost does not separate from the run-to-run spread: 49.2 and 49.3 ms on the document.
+`:strict` adds two checks over `:structural`: a character-range scan of every text, attribute value, comment, CDATA section and processing-instruction body, and a check of every reference in a token that carries one, against the character range for a numeric reference and against the five predefined names for a named one, every declared entity having been included by then. The first costs in proportion to the document's text share, the second to its reference density, and the XMark-style document, which has no reference at all, measures the first alone. `:lenient` and `:structural` differ only in the document-shape checks, whose cost does not separate from the run-to-run spread: 48.1 and 48.9 ms on the document.
 
 | `parse(…, Node; wellformed = …)` | `:structural` | `:strict` | ratio |
 |---|--:|--:|--:|
-| the XMark-style document, text share 57 % | 49.3 ms | 59.8 ms | 1.2× |
-| its escaped twin, 81,799 references | 56.8 ms | 89.8 ms (GC 13.5) | 1.3× |
-| its character data alone, text share 100 %, 8.1 MB | 0.48 ms | 7.1 ms | 15× |
+| the XMark-style document, text share 57 % | 48.9 ms | 59.1 ms | 1.2× |
+| its escaped twin, 81,799 references | 56.4 ms | 68.9 ms | 1.2× |
+| its character data alone, text share 100 %, 8.1 MB | 0.48 ms | 7.0 ms | 15× |
 
 _Table 7 — what `:strict` adds, by document shape; the ratio is taken on the time net of the GC share, the part that reproduces._[^twins]
 
-The character-range scan allocates nothing. The reference check is a regular-expression match per reference: 583,076 allocations on the escaped twin, seven per reference.
+Neither check allocates. The reference check reads the bytes of a token that carries a `&` and copies only a reference it rejects, into its message, so `:strict` allocates exactly what `:structural` does on every document.
 
-libxml2 has no levels: it always enforces well-formedness in full. Its DOM build takes 38 ms on the plain document, 44 ms on the escaped twin and 4.0 ms on its character data alone, so on pure text the C library parses, checks and builds in a little over half the time of the `:strict` character-range scan by itself.
+libxml2 has no levels: it always enforces well-formedness in full. Its DOM build takes 38 ms on the plain document, 45 ms on the escaped twin and 3.9 ms on its character data alone, so on pure text the C library parses, checks and builds in a little over half the time of the `:strict` character-range scan by itself.
 
 ## The other entry points
 
@@ -239,7 +239,7 @@ Stream / low-memory / read-only full-DOM / repeated traversal → **XML.jl**; `F
 
 [^flatbench]: Table 5 (and the README access-pattern table): measured 2026-09-02, same machine, Julia and BenchmarkTools settings; source [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl).
 
-[^twins]: Tables 6 and 7: measured 2026-09-04, same machine and settings as the rest, Julia 1.12.7; BenchmarkTools medians. Source: [`benchmarks/profile.jl`](benchmarks/profile.jl), sections (7) and (8), which generate the twins beside the XMark-style document through the generator's opt-in features.
+[^twins]: Table 6 measured 2026-09-04 and Table 7 2026-09-05, same machine and settings as the rest, Julia 1.12.7; BenchmarkTools medians. Source: [`benchmarks/profile.jl`](benchmarks/profile.jl), sections (7) and (8), which generate the twins beside the XMark-style document through the generator's opt-in features.
 
 [^entrypoints]: Table 8: measured 2026-09-02, same settings; source [`benchmarks/flatnode_bench.jl`](benchmarks/flatnode_bench.jl), its last section, and section (7) of `profile.jl` for the `parse_dtd` row.
 

--- a/src/escape.jl
+++ b/src/escape.jl
@@ -13,10 +13,11 @@ Escape the five XML predefined entities: `&` `<` `>` `'` `"`.
 """
 escape(x::AbstractString) = replace(x, ESCAPE_CHARS...)
 
-# The five names XML 1.0 §4.6 predefines, which need no declaration. `_reference_at` below
-# recognises the same five in the decode path; readers that check what a name refers to use
-# this tuple.
+# The five names XML 1.0 §4.6 predefines, which need no declaration, and the characters they
+# denote, index for index. `_predefined_at` below reads a name against them, for the decoder
+# and for the `:strict` reference check alike; the entity reader tests membership directly.
 const _PREDEFINED = ("amp", "lt", "gt", "apos", "quot")
+const _PREDEFINED_CHARS = ('&', '<', '>', '\'', '"')
 
 #------------------------------------------------------------------------------------# decode
 # `unescape` is one pass over the bytes of its argument into a scratch buffer kept per task,
@@ -26,7 +27,6 @@ const _PREDEFINED = ("amp", "lt", "gt", "apos", "quot")
 # UTF-8, so the runs between references are copied byte for byte. What is emitted is never
 # re-read: a reference that resolves to `&` (`&#38;`) cannot start another one.
 
-@inline _decdigit(b::UInt8) = UInt8('0') <= b <= UInt8('9') ? b - UInt8('0') : 0xff
 @inline function _hexdigit(b::UInt8)
     UInt8('0') <= b <= UInt8('9') && return b - UInt8('0')
     UInt8('a') <= b <= UInt8('f') && return b - UInt8('a') + 0x0a
@@ -34,49 +34,88 @@ const _PREDEFINED = ("amp", "lt", "gt", "apos", "quot")
     return 0xff
 end
 
+# The reference lexer, shared by the decoder below and by the `:strict` reference check in
+# parse.jl. Each helper reads the bytes of one form from a `&` and reports where the form ends
+# and what it denotes; what a caller does with a form it cannot resolve — keep the `&` as
+# written, or reject the document — is the caller's. Every byte a helper decides on is ASCII,
+# hence a character boundary in UTF-8.
+
+# The character reference whose `&#` sits at `i`: `(j, cp)`, the index of its `;` and the code
+# point its digit run denotes, or `j == 0` when the bytes form no reference. `x` or `X` selects
+# the hexadecimal form. The run is read on the hexadecimal alphabet in both forms, and a run the
+# form cannot parse — a letter in the decimal form, a value past U+10FFFF — comes back as
+# `typemax(UInt32)`, outside every character range.
+@inline function _charref_at(cu, i::Int, n::Int)
+    j = i + 2
+    j <= n || return (0, 0x00000000)
+    @inbounds hex = cu[j] == UInt8('x') || cu[j] == UInt8('X')
+    hex && (j += 1)
+    start = j
+    cp = 0x00000000
+    bad = false
+    while j <= n
+        @inbounds d = _hexdigit(cu[j])
+        d == 0xff && break
+        bad |= !hex && d >= 0x0a
+        if !bad
+            cp = cp * (hex ? 0x10 : 0x0a) + d   # cp ≤ 0x10FFFF here, so no UInt32 overflow
+            bad = cp > 0x10FFFF
+        end
+        j += 1
+    end
+    (j > start && j <= n && @inbounds(cu[j]) == UInt8(';')) || return (0, 0x00000000)
+    return (j, bad ? typemax(UInt32) : cp)
+end
+
+# The named reference whose name would start at `a`: the index of its `;`, or 0 when the bytes
+# form no reference. The name is read on the ASCII subset of the Name production (XML 1.0 §2.3).
+@inline function _name_end(cu, a::Int, n::Int)
+    (a <= n && _is_ascii_name_start(@inbounds(cu[a]))) || return 0
+    j = a + 1
+    while j <= n && _is_ascii_name_char(@inbounds(cu[j]))
+        j += 1
+    end
+    return (j <= n && @inbounds(cu[j]) == UInt8(';')) ? j : 0
+end
+@inline _is_ascii_name_start(b::UInt8) =
+    (UInt8('a') <= b <= UInt8('z')) || (UInt8('A') <= b <= UInt8('Z')) || b == UInt8('_') || b == UInt8(':')
+@inline _is_ascii_name_char(b::UInt8) =
+    _is_ascii_name_start(b) || (UInt8('0') <= b <= UInt8('9')) || b == UInt8('.') || b == UInt8('-')
+
+# The predefined reference at `i`, where `cu[i]` is `&`: `(cp, len)`, the character it denotes
+# and its length in code units from the `&` to the `;`, or `len == 0` when the bytes spell none
+# of the five names followed by `;`. The names are taken as byte tuples, so the recursion over
+# them unrolls at compile time and each comparison reads an immediate.
+const _PREDEFINED_BYTES = map(name -> Tuple(codeunits(name)), _PREDEFINED)
+@inline _predefined_at(cu, i::Int, n::Int) = _predefined_at(cu, i, n, _PREDEFINED_BYTES, _PREDEFINED_CHARS)
+@inline _predefined_at(cu, i::Int, n::Int, ::Tuple{}, ::Tuple{}) = (0x00000000, 0)
+@inline function _predefined_at(cu, i::Int, n::Int, names::Tuple, chars::Tuple)
+    name = first(names)
+    len = length(name) + 2   # the `&`, the name, the `;`
+    if i + len - 1 <= n && _spells(cu, i + 1, name) && @inbounds(cu[i + len - 1]) == UInt8(';')
+        return (UInt32(first(chars)), len)
+    end
+    return _predefined_at(cu, i, n, Base.tail(names), Base.tail(chars))
+end
+@inline function _spells(cu, a::Int, name::NTuple{N, UInt8}) where {N}
+    for k in 1:N
+        @inbounds cu[a + k - 1] == name[k] || return false
+    end
+    return true
+end
+
 # Classify the bytes at `i`, where `cu[i]` is `&`: `(cp, len)`, the code point the reference
 # denotes and its length in code units from the `&` to the `;`, or `len == 0` when the bytes
-# form no reference and the `&` is kept as written. Recognised: the five names, case-sensitive;
-# `&#` + decimal digits + `;`; `&#x` or `&#X` + hexadecimal digits + `;`. A numeric reference
-# that `isvalid(Char, cp)` refuses — a surrogate, or past U+10FFFF, digits overflowing included —
-# is no reference either.
+# form no reference the decoder resolves, so that the `&` is kept as written: a `&` that starts
+# neither form, a name that is not one of the five, a numeric reference whose value
+# `isvalid(Char, cp)` refuses — a surrogate, or past U+10FFFF, digits overflowing included.
 @inline function _reference_at(cu, i::Int, n::Int)
-    i + 2 <= n || return (0x00000000, 0)
-    @inbounds b = cu[i + 1]
-    if b == UInt8('#')
-        j = i + 2
-        @inbounds hex = cu[j] == UInt8('x') || cu[j] == UInt8('X')
-        hex && (j += 1)
-        cp = 0x00000000
-        ndigits = 0
-        over = false
-        while j <= n
-            @inbounds d = hex ? _hexdigit(cu[j]) : _decdigit(cu[j])
-            d == 0xff && break
-            ndigits += 1
-            if !over
-                cp = cp * (hex ? 0x10 : 0x0a) + d   # cp ≤ 0x10FFFF here, so no UInt32 overflow
-                over = cp > 0x10FFFF
-            end
-            j += 1
-        end
-        (ndigits > 0 && j <= n && @inbounds(cu[j]) == UInt8(';')) || return (0x00000000, 0)
-        (over || 0xD800 <= cp <= 0xDFFF) && return (0x00000000, 0)
-        return (cp, j - i + 1)
-    elseif b == UInt8('a')
-        if i + 4 <= n && @inbounds(cu[i + 2] == UInt8('m') && cu[i + 3] == UInt8('p') && cu[i + 4] == UInt8(';'))
-            return (UInt32('&'), 5)
-        elseif i + 5 <= n && @inbounds(cu[i + 2] == UInt8('p') && cu[i + 3] == UInt8('o') && cu[i + 4] == UInt8('s') && cu[i + 5] == UInt8(';'))
-            return (UInt32('\''), 6)
-        end
-    elseif b == UInt8('l')
-        i + 3 <= n && @inbounds(cu[i + 2] == UInt8('t') && cu[i + 3] == UInt8(';')) && return (UInt32('<'), 4)
-    elseif b == UInt8('g')
-        i + 3 <= n && @inbounds(cu[i + 2] == UInt8('t') && cu[i + 3] == UInt8(';')) && return (UInt32('>'), 4)
-    elseif b == UInt8('q')
-        i + 5 <= n && @inbounds(cu[i + 2] == UInt8('u') && cu[i + 3] == UInt8('o') && cu[i + 4] == UInt8('t') && cu[i + 5] == UInt8(';')) && return (UInt32('"'), 6)
+    if i + 1 <= n && @inbounds(cu[i + 1]) == UInt8('#')
+        j, cp = _charref_at(cu, i, n)
+        j > 0 && isvalid(Char, cp) && return (cp, j - i + 1)
+        return (0x00000000, 0)
     end
-    return (0x00000000, 0)
+    return _predefined_at(cu, i, n)
 end
 
 # The scratch buffer lives in the task's local storage, so tasks never share it, and grows to

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -159,69 +159,15 @@ function _check_refs_strict(s::AbstractString, names::Bool)
         else
             j = _name_end(cu, i + 1, n)
             if j > 0
-                names && !_is_predefined(cu, i + 1, j - 1) &&
-                    error("not well-formed: reference to undeclared entity \"", String(cu[i:j]), "\" (XML 1.0 §4.1)")
+                if names
+                    _, len = _predefined_at(cu, i, n)
+                    len == 0 && error("not well-formed: reference to undeclared entity \"", String(cu[i:j]), "\" (XML 1.0 §4.1)")
+                end
                 next = j + 1
             end
         end
         i = findnext(==(UInt8('&')), cu, next)   # next ≤ n + 1, where findnext answers `nothing`
     end
-end
-
-# The character reference whose `&#` sits at `i`: `(j, cp)`, the index of its `;` and the code
-# point its digit run denotes, or `j == 0` when the bytes form no reference. `x` or `X` selects
-# the hexadecimal form. The run is read on the hexadecimal alphabet in both forms, and a run the
-# form cannot parse — a letter in the decimal form, a value past U+10FFFF — comes back as
-# `typemax(UInt32)`, outside every character range.
-@inline function _charref_at(cu, i::Int, n::Int)
-    j = i + 2
-    j <= n || return (0, 0x00000000)
-    @inbounds hex = cu[j] == UInt8('x') || cu[j] == UInt8('X')
-    hex && (j += 1)
-    start = j
-    cp = 0x00000000
-    bad = false
-    while j <= n
-        @inbounds d = _hexdigit(cu[j])
-        d == 0xff && break
-        bad |= !hex && d >= 0x0a
-        if !bad
-            cp = cp * (hex ? 0x10 : 0x0a) + d   # cp ≤ 0x10FFFF here, so no UInt32 overflow
-            bad = cp > 0x10FFFF
-        end
-        j += 1
-    end
-    (j > start && j <= n && @inbounds(cu[j]) == UInt8(';')) || return (0, 0x00000000)
-    return (j, bad ? typemax(UInt32) : cp)
-end
-
-# The named reference whose name would start at `a`: the index of its `;`, or 0 when the bytes
-# form no reference. The name is read on the ASCII subset of the Name production (XML 1.0 §2.3).
-@inline function _name_end(cu, a::Int, n::Int)
-    (a <= n && _is_ascii_name_start(@inbounds(cu[a]))) || return 0
-    j = a + 1
-    while j <= n && _is_ascii_name_char(@inbounds(cu[j]))
-        j += 1
-    end
-    return (j <= n && @inbounds(cu[j]) == UInt8(';')) ? j : 0
-end
-@inline _is_ascii_name_start(b::UInt8) =
-    (UInt8('a') <= b <= UInt8('z')) || (UInt8('A') <= b <= UInt8('Z')) || b == UInt8('_') || b == UInt8(':')
-@inline _is_ascii_name_char(b::UInt8) =
-    _is_ascii_name_start(b) || (UInt8('0') <= b <= UInt8('9')) || b == UInt8('.') || b == UInt8('-')
-
-# Whether the bytes `a:b` spell one of the five predefined names, compared byte for byte.
-function _is_predefined(cu, a::Int, b::Int)
-    for name in _PREDEFINED
-        len = ncodeunits(name)
-        len == b - a + 1 || continue
-        k = 1
-        while k <= len && @inbounds(cu[a + k - 1]) == codeunit(name, k)
-            k += 1
-        end
-        k > len && return true
-    end
-    return false
 end
 
 # Token-stream → Node{S} builder. `convert_text` is `unescape` for parsed content (with entity

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -132,22 +132,96 @@ end
 
 # `:strict` only, one pass over a span's references, character and named alike. Gated + DCE'd off
 # the :strict path and called only when a token carries entities, so :lenient/:structural cost
-# nothing. A character reference is rejected when its code point falls outside the XML Char range.
-# A named reference is checked only when `names` holds, and the test is then a membership one:
-# `_expand_entities` has already replaced every reference it could resolve, so a name arriving
-# here that is not predefined has no replacement text behind it (XML 1.0 §4.1, the "Entity
-# Declared" well-formedness constraint). A name outside the ASCII set the pattern accepts goes unchecked, which costs a
-# missed rejection and never a wrong one.
+# nothing. The pass reads code units: every byte it decides on — `&`, `#`, `x`, a digit, a letter
+# of a name, `;` — is ASCII, hence a character boundary, and a span it accepts allocates nothing;
+# only a rejected reference is copied, into its message. A character reference is rejected when
+# its digit run denotes no code point of the XML Char range; the run is read on the hexadecimal
+# alphabet in both forms, so a decimal form carrying a letter is rejected too. A named reference
+# is checked only when `names` holds, and the test is then a membership one: `_expand_entities`
+# has already replaced every reference it could resolve, so a name arriving here that is not
+# predefined has no replacement text behind it (XML 1.0 §4.1, the "Entity Declared"
+# well-formedness constraint). A `&` that starts neither form — a name outside the ASCII set the
+# pass accepts, a digit run without its `;` — goes unchecked, which costs a missed rejection and
+# never a wrong one.
 function _check_refs_strict(s::AbstractString, names::Bool)
-    for m in eachmatch(r"&(?:#([xX]?)([0-9a-fA-F]+)|([A-Za-z_:][A-Za-z0-9._:-]*));", s)
-        if m[3] === nothing
-            cp = tryparse(UInt32, m[2]; base = isempty(m[1]) ? 10 : 16)
-            (cp === nothing || !_is_xml_char(cp)) &&
-                error("not well-formed: illegal character reference \"&#$(m[1])$(m[2]);\"")
-        elseif names && !(m[3] in _PREDEFINED)
-            error("not well-formed: reference to undeclared entity \"&$(m[3]);\" (XML 1.0 §4.1)")
+    cu = codeunits(s)
+    n = length(cu)
+    i = findnext(==(UInt8('&')), cu, 1)
+    while i !== nothing
+        next = i + 1
+        if i + 1 <= n && @inbounds(cu[i + 1]) == UInt8('#')
+            j, cp = _charref_at(cu, i, n)
+            if j > 0
+                _is_xml_char(cp) ||
+                    error("not well-formed: illegal character reference \"", String(cu[i:j]), "\"")
+                next = j + 1
+            end
+        else
+            j = _name_end(cu, i + 1, n)
+            if j > 0
+                names && !_is_predefined(cu, i + 1, j - 1) &&
+                    error("not well-formed: reference to undeclared entity \"", String(cu[i:j]), "\" (XML 1.0 §4.1)")
+                next = j + 1
+            end
         end
+        i = findnext(==(UInt8('&')), cu, next)   # next ≤ n + 1, where findnext answers `nothing`
     end
+end
+
+# The character reference whose `&#` sits at `i`: `(j, cp)`, the index of its `;` and the code
+# point its digit run denotes, or `j == 0` when the bytes form no reference. `x` or `X` selects
+# the hexadecimal form. The run is read on the hexadecimal alphabet in both forms, and a run the
+# form cannot parse — a letter in the decimal form, a value past U+10FFFF — comes back as
+# `typemax(UInt32)`, outside every character range.
+@inline function _charref_at(cu, i::Int, n::Int)
+    j = i + 2
+    j <= n || return (0, 0x00000000)
+    @inbounds hex = cu[j] == UInt8('x') || cu[j] == UInt8('X')
+    hex && (j += 1)
+    start = j
+    cp = 0x00000000
+    bad = false
+    while j <= n
+        @inbounds d = _hexdigit(cu[j])
+        d == 0xff && break
+        bad |= !hex && d >= 0x0a
+        if !bad
+            cp = cp * (hex ? 0x10 : 0x0a) + d   # cp ≤ 0x10FFFF here, so no UInt32 overflow
+            bad = cp > 0x10FFFF
+        end
+        j += 1
+    end
+    (j > start && j <= n && @inbounds(cu[j]) == UInt8(';')) || return (0, 0x00000000)
+    return (j, bad ? typemax(UInt32) : cp)
+end
+
+# The named reference whose name would start at `a`: the index of its `;`, or 0 when the bytes
+# form no reference. The name is read on the ASCII subset of the Name production (XML 1.0 §2.3).
+@inline function _name_end(cu, a::Int, n::Int)
+    (a <= n && _is_ascii_name_start(@inbounds(cu[a]))) || return 0
+    j = a + 1
+    while j <= n && _is_ascii_name_char(@inbounds(cu[j]))
+        j += 1
+    end
+    return (j <= n && @inbounds(cu[j]) == UInt8(';')) ? j : 0
+end
+@inline _is_ascii_name_start(b::UInt8) =
+    (UInt8('a') <= b <= UInt8('z')) || (UInt8('A') <= b <= UInt8('Z')) || b == UInt8('_') || b == UInt8(':')
+@inline _is_ascii_name_char(b::UInt8) =
+    _is_ascii_name_start(b) || (UInt8('0') <= b <= UInt8('9')) || b == UInt8('.') || b == UInt8('-')
+
+# Whether the bytes `a:b` spell one of the five predefined names, compared byte for byte.
+function _is_predefined(cu, a::Int, b::Int)
+    for name in _PREDEFINED
+        len = ncodeunits(name)
+        len == b - a + 1 || continue
+        k = 1
+        while k <= len && @inbounds(cu[a + k - 1]) == codeunit(name, k)
+            k += 1
+        end
+        k > len && return true
+    end
+    return false
 end
 
 # Token-stream → Node{S} builder. `convert_text` is `unescape` for parsed content (with entity

--- a/test/suite.jl
+++ b/test/suite.jl
@@ -281,6 +281,15 @@ end
         @test_throws Exception parse("""<e a="&#0;"/>""", Node; wellformed=:strict)        # in an attribute too
         # legal refs still parse under :strict
         @test simple_value(parse("<root>&#x41;&#x9;</root>", Node; wellformed=:strict)[1]) == "A\t"
+        # The edges of the range, both forms, leading zeros, and the digit run the check reads: the
+        # run is taken on the hexadecimal alphabet in both forms, so a decimal form carrying a letter
+        # is illegal, as a value past the range is; a `&#` that no digit run and `;` complete starts
+        # no reference and is left as written.
+        @test nodetype(parse("<root>&#x10FFFF;&#xE000;&#xFFFD;&#x20;&#X41;&#0000000065;</root>", Node; wellformed=:strict)) == Document
+        for ref in ("&#x110000;", "&#xFFFE;", "&#xDFFF;", "&#31;", "&#12a;", "&#99999999999;")
+            @test_throws "illegal character reference \"$ref\"" parse("<root>$ref</root>", Node; wellformed=:strict)
+        end
+        @test nodetype(parse("<root>&#; &#x; &#65 &#x41x; &#xx41;</root>", Node; wellformed=:strict)) == Document
 
         # The RAW (literal) form of an illegal character is rejected too, not only the reference
         # form — in text, attributes, comments, CDATA, and PI content.
@@ -428,6 +437,12 @@ end
         # the five predefined names and character references name no declaration to look up
         @test nodetype(parse("<a>&amp;&lt;&gt;&apos;&quot;</a>", Node; wellformed=:strict)) == Document
         @test nodetype(parse("<a>&#65;&#x42;</a>", Node; wellformed=:strict)) == Document
+        # The name is read on the ASCII subset of the Name production, case-sensitive, up to its `;`:
+        # a `&` that starts no such name is left as written, and a name that is not one of the five
+        # is named by the message.
+        @test_throws "reference to undeclared entity \"&AMP;\"" parse("<a>&AMP;</a>", Node; wellformed=:strict)
+        @test_throws "reference to undeclared entity \"&_x.y-z:1;\"" parse("<a>&_x.y-z:1;</a>", Node; wellformed=:strict)
+        @test nodetype(parse("<a>&; & &1a; &-a; &é; &amp &&amp;</a>", Node; wellformed=:strict)) == Document
         # a declared entity resolves, so nothing of it reaches the check
         @test nodetype(parse("<!DOCTYPE a [<!ENTITY e \"x\">]><a>&e;</a>", Node; wellformed=:strict)) == Document
         # The constraint binds only where the document carries every declaration that could name
@@ -441,6 +456,41 @@ end
         # below :strict the reference stays literal — the graceful degradation
         @test value(children(parse("<a>&foo;</a>", Node)[end])[1]) == "&foo;"
         @test value(children(parse("<a>&foo;</a>", Node; wellformed=:lenient)[end])[1]) == "&foo;"
+    end
+
+    @testset "every short span gets the verdict and message of the pattern-based check" begin
+        # The reference is the check as it read with a pattern, kept here as the specification:
+        # one `eachmatch` with three groups, a `tryparse` of the digit run against the character
+        # range, a membership test of the name against the five predefined ones. Its verdict —
+        # accepted, or the message it raises — is what the byte scan reproduces, `names` on and off.
+        function pattern_check(s, names)
+            for m in eachmatch(r"&(?:#([xX]?)([0-9a-fA-F]+)|([A-Za-z_:][A-Za-z0-9._:-]*));", s)
+                if m[3] === nothing
+                    cp = tryparse(UInt32, m[2]; base = isempty(m[1]) ? 10 : 16)
+                    (cp === nothing || !XML._is_xml_char(cp)) &&
+                        error("not well-formed: illegal character reference \"&#$(m[1])$(m[2]);\"")
+                elseif names && !(m[3] in XML._PREDEFINED)
+                    error("not well-formed: reference to undeclared entity \"&$(m[3]);\" (XML 1.0 §4.1)")
+                end
+            end
+        end
+        verdict(check, s, names) = try; check(s, names); "accepted"; catch e; sprint(showerror, e); end
+        # Every string of one to four tokens over an alphabet that can spell each reference form,
+        # each edge of the character range, a broken form and multibyte text: 406,900 strings,
+        # `String` and `SubString` alike, `names` on and off.
+        tokens = ("&#x", "&#", "&", "X", ";", "1", "a", "F", "0", "D800", "10FFFF", "110000", "FFFE",
+                  "9999999999", "amp", "lt", "quot", "AMP", "foo", "_", ".", ":", "é", "😀", " ")
+        mismatches = String[]
+        for len in 1:4, idx in Iterators.product(ntuple(_ -> eachindex(tokens), len)...)
+            s = join(tokens[i] for i in idx)
+            for names in (true, false)
+                want = verdict(pattern_check, s, names)
+                (verdict(XML._check_refs_strict, s, names) == want &&
+                 verdict(XML._check_refs_strict, SubString(s), names) == want) || push!(mismatches, s)
+            end
+            length(mismatches) >= 10 && break
+        end
+        @test mismatches == String[]
     end
 end
 

--- a/test/test_allocations.jl
+++ b/test/test_allocations.jl
@@ -260,3 +260,30 @@ measure_eol_rewrite(s) = Base.@allocations XML._rewrite_content_eol(s)
         @test measure_eol_rewrite(v) <= 3
     end
 end
+
+# `:strict` reference check — the contract: on a token that carries a `&`, the check reads the
+# code units and copies nothing on a span it accepts, so the level allocates exactly what
+# `:structural` allocates on a document full of references. The direct guard holds the check
+# to zero; the parse-level one holds `:strict` to the count of `:structural`, the acceptance
+# line of section (8) of `benchmarks/profile.jl`, and covers the character-range scan too.
+measure_refcheck(s, names)    = Base.@allocations XML._check_refs_strict(s, names)
+measure_parse_strict(xml)     = Base.@allocations parse(xml, Node; wellformed = :strict)
+measure_parse_structural(xml) = Base.@allocations parse(xml, Node; wellformed = :structural)
+
+@testset ":strict reference check: allocation-free on an accepted span" begin
+    span = "a &amp; b &#65; c &#x42; d &quot;&apos;&lt;&gt; e &#x1F600;"
+    sub = SubString("<" * span * ">", 2, ncodeunits(span) + 1)
+    @test XML._check_refs_strict(sub, true) === nothing
+    @test XML._check_refs_strict(span, false) === nothing
+    refs_xml = "<root>" * repeat("<e a=\"&amp;&#65;\">x &lt; &#x42; &quot;y&quot;</e>", 200) * "</root>"
+    doc = parse(refs_xml, Node; wellformed = :strict)
+    @test length(children(only(children(doc)))) == 200
+    @test doc == parse(refs_xml, Node; wellformed = :structural)
+    measure_refcheck(sub, true); measure_refcheck(span, false)               # warm-up
+    measure_parse_strict(refs_xml); measure_parse_structural(refs_xml)
+    if _NO_COVERAGE
+        @test measure_refcheck(sub, true) == 0
+        @test measure_refcheck(span, false) == 0
+        @test measure_parse_strict(refs_xml) == measure_parse_structural(refs_xml)
+    end
+end


### PR DESCRIPTION
Closes #142.

`parse(…; wellformed = :strict)` allocated about seven times per reference, in the `Node` and `FlatNode` parses alike. The check matched a regular expression with three groups per reference. Each match cost a `RegexMatch` and its captures, and a numeric reference a `SubString` for `tryparse` besides.

The check now reads the bytes of a token that carries a `&` and allocates nothing. Each `&` is found with `findnext` over the code units. A numeric reference has its digit run accumulated and tested against the XML Char range. A named one is compared byte for byte with the five predefined names, when the "Entity Declared" constraint applies. Only a rejected reference is copied, into its message.

What the check accepts, rejects and ignores is unchanged, message included. The digit run is read on the hexadecimal alphabet in both forms, as the pattern read it, so a decimal form carrying a letter is still rejected. A `&` that starts neither form is still left unchecked. The test suite pins this with a comparison against the pattern-based check, kept as the specification. It covers every string of one to four tokens over an alphabet that spells each reference form, each edge of the character range, a broken form and multibyte text: 406,900 strings. Each is checked as `String` and as `SubString`, `names` on and off, verdict and message compared. The edges are listed one by one as well. Allocation guards hold the check at zero, and `parse(…; wellformed = :strict)` at the allocation count of `:structural` on a document of references.

The decoder and the check now share one reference lexer. `unescape` resolves a reference through the same helpers, with its own outcomes, and the five names and the characters they denote sit in one place. Its outcomes are unchanged, pinned by the 579,194-string comparison of #144.

## Measured

Section (8) of `benchmarks/profile.jl`, escaped twin of #140, 81,799 references; BenchmarkTools medians, Julia 1.12.7, final commit:

| row | before | after |
|---|--:|--:|
| `escaped :strict` | 89.8 ms (GC 13.5) · 3,241,570 | 68.9 ms · 2,658,494 |
| `escaped :structural` (control) | 56.8 ms · 2,658,494 | 56.4 ms · 2,658,494 |
| `plain :strict` (control) | 59.8 ms · 2,526,927 | 59.1 ms · 2,526,927 |
| `text-only :strict` (control) | 7.05 ms · 18 | 6.97 ms · 18 |

The acceptance line of #142 was `escaped :strict` at the allocation count of `escaped :structural`.

Per call, on a value of a spreadsheet cell's shape, `A &amp; B &lt;tag&gt;`: 281 ns and 19 allocations → 17 ns and 0. On a 98-byte text token with one reference: 117 ns and 8 → 8 ns and 0. `unescape` on the same cell value: 33 → 34 ns, within the run-to-run spread. The shared-strings cells of `benchmarks/benchmarks.jl` move within noise: `Node` build 9.93 ms unchanged, normalized write 51.6 → 50.7, entity-heavy `sst_load!` 19.7 → 19.8.

## Docs

- `PERFORMANCE-v0.4.md`: Table 7 republished from this campaign, its note dated per table; the sentence under it no longer describes a pattern match per reference. Table 6, `benchmarks_results.md` and the README table keep the figures of #144: nothing they measure depends on this change, and the same campaign re-measured them within noise.
- `CHANGELOG.md`: a Fixed entry.

## Left out

`_check_chars_strict`, the character-range scan `:strict` runs on every token, is #143. `entities.jl` still resolves the character references of an entity's replacement text with its own regular expression, once per declaration, off the per-value path.