### PR TITLE
Benchmarks: one evaluation per sample on every cell that builds a C tree

### DIFF
--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -52,18 +52,21 @@ const SSNode = Node{SubString{String}}
 @add_benchmark "Parse (medium)" "XML.jl (SS)" parse($medium_xml, SSNode)
 # C-tree lifetime, small and medium cells alike: LightXML attaches no finalizer, so an unfreed parse
 # leaks its whole tree outright; EzXML attaches one to the document's node, not to the document,
-# so `finalize(doc)` frees nothing and `finalize(doc.node)` is the call — and a benchmark loop
-# allocates too little in Julia to wake the collector, so trees left to it pile up by the
-# gigabyte until the machine pages. Every C-tree cell therefore releases its tree per sample
-# (teardown, untimed; the small parse cells run one evaluation per sample so that the teardown
-# reaches every tree): LightXML.free / finalize(doc.node) — both free C memory without touching
-# the Julia GC, so cell timings are unchanged. XMLDict's internal EzXML document is
-# unreachable from outside and its per-cell C residue is small (~50 MiB per sample at ~14
-# samples); it is left to the between-cell GC.gc() in @add_benchmark — a per-sample
-# collection would reset the young generation inside the cell and hide the GC cost the
-# allocation-heavy conversion incurs in real use.
-@add_benchmark "Parse (medium)" "EzXML" (d[] = EzXML.parsexml($medium_xml)) setup=(d = Ref{Any}(nothing)) teardown=(d[] === nothing || finalize(d[].node); d[] = nothing)
-@add_benchmark "Parse (medium)" "LightXML" (d[] = LightXML.parse_string($medium_xml)) setup=(d = Ref{Any}(nothing)) teardown=(d[] === nothing || LightXML.free(d[]); d[] = nothing)
+# so `finalize(doc)` frees nothing and `finalize(doc.node)` is the call (reported upstream as
+# JuliaIO/EzXML.jl#220) — and a benchmark loop allocates too little in Julia to wake the
+# collector, so trees left to it pile up by the gigabyte until the machine pages. Every cell whose
+# body builds a C tree therefore releases it per sample (teardown, untimed) and runs one
+# evaluation per sample, `evals=1`: BenchmarkTools runs setup and teardown once per sample, and
+# its tuning phase raises the evaluations per sample until a sample lasts long enough, so a cell
+# left to tune builds one tree per evaluation and frees one per sample — about a hundred trees of
+# 120 MB for a 40 ms parse, held until the next full collection. LightXML.free / finalize(doc.node)
+# both free C memory without touching the Julia GC, so cell timings are unchanged. XMLDict's
+# internal EzXML document is unreachable from outside and its per-cell C residue is small
+# (~50 MiB per sample at ~14 samples); it is left to the between-cell GC.gc() in @add_benchmark
+# — a per-sample collection would reset the young generation inside the cell and hide the GC
+# cost the allocation-heavy conversion incurs in real use.
+@add_benchmark "Parse (medium)" "EzXML" (d[] = EzXML.parsexml($medium_xml)) setup=(d = Ref{Any}(nothing)) teardown=(d[] === nothing || finalize(d[].node); d[] = nothing) evals=1
+@add_benchmark "Parse (medium)" "LightXML" (d[] = LightXML.parse_string($medium_xml)) setup=(d = Ref{Any}(nothing)) teardown=(d[] === nothing || LightXML.free(d[]); d[] = nothing) evals=1
 @add_benchmark "Parse (medium)" "XMLDict" XMLDict.xml_dict($medium_xml)
 
 #-----------------------------------------------------------------------------# Write (small)
@@ -78,8 +81,8 @@ const SSNode = Node{SubString{String}}
 
 #-----------------------------------------------------------------------------# Read from file
 @add_benchmark "Read file" "XML.jl" read($medium_file, Node)
-@add_benchmark "Read file" "EzXML" (d[] = EzXML.readxml($medium_file)) setup=(d = Ref{Any}(nothing)) teardown=(d[] === nothing || finalize(d[].node); d[] = nothing)
-@add_benchmark "Read file" "LightXML" (d[] = LightXML.parse_file($medium_file)) setup=(d = Ref{Any}(nothing)) teardown=(d[] === nothing || LightXML.free(d[]); d[] = nothing)
+@add_benchmark "Read file" "EzXML" (d[] = EzXML.readxml($medium_file)) setup=(d = Ref{Any}(nothing)) teardown=(d[] === nothing || finalize(d[].node); d[] = nothing) evals=1
+@add_benchmark "Read file" "LightXML" (d[] = LightXML.parse_file($medium_file)) setup=(d = Ref{Any}(nothing)) teardown=(d[] === nothing || LightXML.free(d[]); d[] = nothing) evals=1
 
 #-----------------------------------------------------------------------------# Collect element tags
 function xml_collect_tags(node)

--- a/benchmarks/flatnode_bench.jl
+++ b/benchmarks/flatnode_bench.jl
@@ -49,7 +49,7 @@ cell("build FlatNode", @benchmark(parse($xml, FlatNode)); alloc = true)
 cell("build Node",     @benchmark(parse($xml, Node));     alloc = true)
 # The C tree is freed per sample outside the timing, through the document's node, which is where
 # EzXML attaches its finalizer; Julia alloc is not meaningful for it.
-cell("build EzXML",    @benchmark((d[] = EzXML.parsexml($xml)), setup = (d = Ref{Any}(nothing)), teardown = (d[] === nothing || finalize(d[].node); d[] = nothing)))
+cell("build EzXML",    @benchmark((d[] = EzXML.parsexml($xml)), setup = (d = Ref{Any}(nothing)), teardown = (d[] === nothing || finalize(d[].node); d[] = nothing), evals = 1))
 # LazyNode materializes nothing, so its "build" is the document entry alone: one line-end
 # scan of the source (§2.11), allocation-free, proportional to document size.
 cell("open LazyNode",  @benchmark(parse($xml, LazyNode));  alloc = true)

--- a/benchmarks/profile.jl
+++ b/benchmarks/profile.jl
@@ -165,8 +165,8 @@ row("EzXML StreamReader", @benchmark ezxml_stream($S))
 println("\n=== (2) FULL EXTRACTION — parse + pull every tag/text ===")
 row("XML.jl (String)",    @benchmark xml_extract($S, Node))
 row("XML.jl (SubString)", @benchmark xml_extract($S, SSNode))
-row("EzXML",              @benchmark (d[] = EzXML.parsexml($S); ezxml_walk(EzXML.root(d[]))) setup = (d = Ref{Any}(nothing)) teardown = (d[] === nothing || finalize(d[].node); d[] = nothing))
-row("LightXML (elem)",    @benchmark (d[] = LightXML.parse_string($S); lightxml_walk(LightXML.root(d[]))) setup = (d = Ref{Any}(nothing)) teardown = (d[] === nothing || LightXML.free(d[]); d[] = nothing))
+row("EzXML",              @benchmark (d[] = EzXML.parsexml($S); ezxml_walk(EzXML.root(d[]))) setup = (d = Ref{Any}(nothing)) teardown = (d[] === nothing || finalize(d[].node); d[] = nothing) evals = 1)
+row("LightXML (elem)",    @benchmark (d[] = LightXML.parse_string($S); lightxml_walk(LightXML.root(d[]))) setup = (d = Ref{Any}(nothing)) teardown = (d[] === nothing || LightXML.free(d[]); d[] = nothing) evals = 1)
 
 println("\n=== (3) DECOMPOSE — XML.jl pipeline stages ===")
 const TREE = parse(S, Node)
@@ -243,7 +243,7 @@ println("\n(the entry either passes the mapping through or rewrites the document
 # difference below belongs to the entity machinery and to nothing else. The twin declares three
 # entities and references them where the plain document carries the words themselves, so those
 # references disappear into the expansion; a fourth word is rewritten as a character reference,
-# which survives the expansion and is what reaches the `:strict` reference check. Both
+# which crosses the expansion and is what reaches the `:strict` reference check. Both
 # populations are needed: `has_entities` is computed after the expansion, so a twin carrying
 # only declared references would leave that check measuring nothing.
 
@@ -339,7 +339,7 @@ for (lbl, s, lz, fl) in (("plain", S, LAZY, FLAT), ("escaped", SESC, LAZY_E, FLA
     row("attr sweep, $lbl",      @benchmark attr_sweep($lz))
     row("FlatNode walk, $lbl",   @benchmark traverse_walk($fl))
     row("EzXML stream, $lbl",    @benchmark ezxml_stream($s))
-    row("EzXML DOM, $lbl",       @benchmark (d[] = EzXML.parsexml($s)) setup = (d = Ref{Any}(nothing)) teardown = (d[] === nothing || finalize(d[].node); d[] = nothing))
+    row("EzXML DOM, $lbl",       @benchmark (d[] = EzXML.parsexml($s)) setup = (d = Ref{Any}(nothing)) teardown = (d[] === nothing || finalize(d[].node); d[] = nothing) evals = 1)
 end
 const DTD_VALUE = XML.value(first(c for c in XML.children(LAZY_M) if XML.nodetype(c) === XML.DTD))
 mrow("parse_dtd, the schema",   @benchmark XML.parse_dtd($DTD_VALUE))
@@ -349,7 +349,7 @@ println("\n(same rows as (1), (2) and (4) over the three documents; the DOCTYPE 
 #--------------------------------------------------------------# (8) WELL-FORMEDNESS LEVELS
 # What `wellformed = :strict` adds over `:structural`: a character-range scan of every text,
 # attribute value, comment, CDATA section and processing-instruction body, and a check of every
-# character reference in a token that carries one. The first scales with the document's text
+# reference in a token that carries one. The first scales with the document's text
 # share, the second with its reference density. The plain document measures the first alone, its
 # escaped twin both, and a document made of the XMark-style document's character data alone puts the text share
 # at one. `:lenient` and `:structural` differ only in the document-shape checks.
@@ -368,7 +368,7 @@ row("text-only :strict",     @benchmark parse($TEXT_ONLY, Node; wellformed = :st
 # libxml2 has no levels: it always enforces well-formedness in full, so its rows are the reference
 # of a parser that checks everything, on the same three documents.
 for (lbl, s) in (("plain", S), ("escaped", SESC), ("text-only", TEXT_ONLY))
-    row("EzXML DOM, $lbl",       @benchmark (d[] = EzXML.parsexml($s)) setup = (d = Ref{Any}(nothing)) teardown = (d[] === nothing || finalize(d[].node); d[] = nothing))
+    row("EzXML DOM, $lbl",       @benchmark (d[] = EzXML.parsexml($s)) setup = (d = Ref{Any}(nothing)) teardown = (d[] === nothing || finalize(d[].node); d[] = nothing) evals = 1)
 end
 println("\n(the character-range scan costs in proportion to the text share; the reference check",
         "\n runs only on a token that carries a `&`, so never on the plain document)")


### PR DESCRIPTION
A campaign under Julia 1.13.0 drove the machine into swap: `profile.jl` reached 11.5 GB of resident memory within eight minutes.

The leak is in the tuning phase of BenchmarkTools, on every Julia version. `tune!` raises the evaluations per sample until a sample lasts long enough, while `setup` and `teardown` run once per sample. A cell whose body builds a libxml2 tree therefore builds one tree per evaluation and frees one per sample: about a hundred trees of 120 MB for a 40 ms parse, held until the next full collection. #140 set `evals = 1` on the small parse cells alone.

Measured on the `EzXML DOM` row of `profile.jl`: `tune!` alone takes resident memory from 294 MiB to 13.2 GB; with `evals = 1` the cell stays at 438 MiB after 30 samples.

Every cell whose body builds a C tree now passes `evals = 1`, nine cells over the three scripts; the lifetime comment in `benchmarks.jl` describes the ramp and points to the upstream report on EzXML's finalizer. The published figures do not move: these cells already ran one evaluation per sample in the measured run. No CHANGELOG entry.