### PR TITLE
CI: cache the Julia depot

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,9 @@ on:
     branches: [main, dev]
     tags: ["*"]
   pull_request:
+permissions:
+  actions: write
+  contents: read
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -30,16 +33,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v6
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v3
       - uses: actions/cache@v6
         with:
           path: test/data/w3c
@@ -73,16 +67,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: x64
-      - uses: actions/cache@v6
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v3
       - uses: actions/cache@v6
         with:
           path: test/data/w3c

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -5,6 +5,10 @@ on:
     tags: [v*]
   pull_request:
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   test:
     name: ${{ matrix.package }} - Julia ${{ matrix.version }}
@@ -28,6 +32,7 @@ jobs:
           version: ${{ matrix.version }}
           arch: x64
           show-versioninfo: true
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@latest
       - name: Load this and run the downstream tests
         shell: julia --color=yes {0}


### PR DESCRIPTION
The `[julia-buildpkg]` notice on every job says it: no depot cache is restored. The workflow's only Julia cache keyed on `~/.julia/artifacts`, a directory this package never creates, so it never hit and never saved.

`julia-actions/cache@v3` replaces it in both CI jobs and is added to Downstream: registries, packages and compiled code are restored per job and matrix cell, and the previous cache of the key is deleted, which needs `actions: write` on the token.

On the last run of `main`, the work this can save per job is the test-dependency and coverage-tool precompilation plus buildpkg: about 15 s on Linux and 40 s on the Intel macOS runner. Downstream installs XLSX and SatelliteToolboxOrbitDataMessages with their dependencies on every run and should gain more.