### PR TITLE
CI: pass --check-bounds=auto to the default-bounds job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,4 +76,4 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         with:
           coverage: false
-          julia_args: '--check-bounds=auto'
+          check_bounds: 'auto'


### PR DESCRIPTION
The "default-bounds allocation guards" job passes `julia_args: '--check-bounds=auto'` to `julia-actions/julia-runtest@v1`, an input the action does not declare. The runner has annotated every run with "Unexpected input(s) 'julia_args'" since the job was added in ec271f9, and the action ignored the value. The job ran with `--check-bounds=yes` like the others, so the noshift span reconstruction it exists to test never ran in CI.

`check_bounds: 'auto'` is the declared input; the action turns it into `--check-bounds=auto` on the `Pkg.test` command. The suite passes under that flag locally with coverage off, 4610 tests.